### PR TITLE
Add RouterBase agent skills

### DIFF
--- a/skills/routerbase-api-integration/SKILL.md
+++ b/skills/routerbase-api-integration/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: "RouterBase API Integration"
+slug: "routerbase-api-integration"
+description: "Integrate agent applications with RouterBase as an OpenAI-compatible API gateway, including SDK base URL configuration, streaming, tool calling, JSON mode, retries, and safe API key handling."
+category: "Integrations & Connectors"
+framework: "Multi-Framework"
+verification: "listed"
+source: "https://routerbase.com/"
+---
+
+# RouterBase API Integration
+
+Use [routerbase](https://routerbase.com/) when an agent application needs one OpenAI-compatible integration surface for model calls. This skill helps operators migrate existing OpenAI SDK usage by changing the base URL, keeping provider credentials out of prompts and repositories, and verifying that chat completion, streaming, tool calling, and structured JSON response paths still behave as expected.
+
+The workflow is intentionally implementation-oriented. Start by locating the current model client, environment variables, request timeouts, and retry policy. Configure the RouterBase endpoint through runtime configuration instead of hard-coding it in source files. Preserve the existing request shape where possible, then run a smoke test for normal chat, streamed output, function or tool calls, and error handling. Before merging, inspect logs and generated examples to confirm no real API keys, bearer tokens, private emails, or account identifiers were copied into the skill, tests, or documentation.
+
+## Installation
+
+### OpenClaw
+
+```bash
+clawhub install routerbase-api-integration
+```
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill directory into the skill folder used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/routerbase-api-integration ~/.agent-skills/routerbase-api-integration
+```
+
+### Optional Third-Party Installer
+
+The `skills` npm package is maintained by Vercel Labs / third parties, not AgentSkillExchange. If you choose to use it, pin the package version:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill routerbase-api-integration
+```
+
+## Source
+
+- [routerbase](https://routerbase.com/)

--- a/skills/routerbase-api-integration/SKILL.md
+++ b/skills/routerbase-api-integration/SKILL.md
@@ -28,7 +28,7 @@ Clone the Agent Skill Exchange repository and copy this skill directory into the
 
 ```bash
 git clone https://github.com/agentskillexchange/skills.git
-cp -R skills/skills/routerbase-api-integration ~/.agent-skills/routerbase-api-integration
+cp -R skills/routerbase-api-integration ~/.agent-skills/routerbase-api-integration
 ```
 
 ### Optional Third-Party Installer

--- a/skills/routerbase-media-generation/SKILL.md
+++ b/skills/routerbase-media-generation/SKILL.md
@@ -28,7 +28,7 @@ Clone the Agent Skill Exchange repository and copy this skill directory into the
 
 ```bash
 git clone https://github.com/agentskillexchange/skills.git
-cp -R skills/skills/routerbase-media-generation ~/.agent-skills/routerbase-media-generation
+cp -R skills/routerbase-media-generation ~/.agent-skills/routerbase-media-generation
 ```
 
 ### Optional Third-Party Installer

--- a/skills/routerbase-media-generation/SKILL.md
+++ b/skills/routerbase-media-generation/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: "RouterBase Media Generation"
+slug: "routerbase-media-generation"
+description: "Build RouterBase media generation workflows for image, audio, speech, and video tasks, covering endpoint selection, request schemas, polling, retries, asset storage, moderation, and failure handling."
+category: "Image & Creative Automation"
+framework: "Multi-Framework"
+verification: "listed"
+source: "https://routerbase.com/"
+---
+
+# RouterBase Media Generation
+
+Use [routerbase](https://routerbase.com/) when an agent workflow needs to generate or transform media through a shared API gateway. This skill focuses on implementation planning for image, audio, speech, and video generation tasks: selecting the right endpoint or model family, shaping prompts and metadata, handling asynchronous jobs, storing returned assets, and keeping generated files traceable without exposing private user data.
+
+Begin by classifying the requested media type, expected output format, size constraints, safety requirements, and whether the result is synchronous or requires polling. Then define request schemas, retry limits, idempotency behavior, and a storage convention for generated files. Agents should keep prompt text, generated URLs, and binary assets out of permanent logs unless the user explicitly asks to preserve them. Before release, test at least one successful generation path, one provider error, one timeout, and one invalid input case so the workflow can explain what failed and whether a retry is safe.
+
+## Installation
+
+### OpenClaw
+
+```bash
+clawhub install routerbase-media-generation
+```
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill directory into the skill folder used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/routerbase-media-generation ~/.agent-skills/routerbase-media-generation
+```
+
+### Optional Third-Party Installer
+
+The `skills` npm package is maintained by Vercel Labs / third parties, not AgentSkillExchange. If you choose to use it, pin the package version:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill routerbase-media-generation
+```
+
+## Source
+
+- [routerbase](https://routerbase.com/)

--- a/skills/routerbase-model-routing/SKILL.md
+++ b/skills/routerbase-model-routing/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: "RouterBase Model Routing"
+slug: "routerbase-model-routing"
+description: "Design RouterBase model routing policies for AI agents, including primary model selection, fallback chains, latency budgets, cost controls, rollout checks, and provider-specific capability notes."
+category: "Developer Tools"
+framework: "Multi-Framework"
+verification: "listed"
+source: "https://routerbase.com/"
+---
+
+# RouterBase Model Routing
+
+Use [routerbase](https://routerbase.com/) when an agent needs a practical model routing plan instead of a single hard-coded model. This skill guides the agent through matching workloads to model capabilities, defining fallback behavior, and documenting the tradeoffs that matter during production rollout: latency, cost, context length, tool calling support, structured output reliability, and media or multimodal capability.
+
+The routing process starts with a workload inventory. Separate cheap classification, high-context analysis, tool-heavy agent loops, media generation, and final user-facing synthesis into different traffic classes. For each class, choose a primary model, one or two fallback models, retry limits, timeout budgets, and a logging plan that records route decisions without storing sensitive prompts or credentials. During validation, run a small prompt set through every route, compare output quality, verify error handling, and write down when the system should fail closed rather than silently degrading to a model that cannot support the requested feature.
+
+## Installation
+
+### OpenClaw
+
+```bash
+clawhub install routerbase-model-routing
+```
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill directory into the skill folder used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/routerbase-model-routing ~/.agent-skills/routerbase-model-routing
+```
+
+### Optional Third-Party Installer
+
+The `skills` npm package is maintained by Vercel Labs / third parties, not AgentSkillExchange. If you choose to use it, pin the package version:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill routerbase-model-routing
+```
+
+## Source
+
+- [routerbase](https://routerbase.com/)

--- a/skills/routerbase-model-routing/SKILL.md
+++ b/skills/routerbase-model-routing/SKILL.md
@@ -28,7 +28,7 @@ Clone the Agent Skill Exchange repository and copy this skill directory into the
 
 ```bash
 git clone https://github.com/agentskillexchange/skills.git
-cp -R skills/skills/routerbase-model-routing ~/.agent-skills/routerbase-model-routing
+cp -R skills/routerbase-model-routing ~/.agent-skills/routerbase-model-routing
 ```
 
 ### Optional Third-Party Installer


### PR DESCRIPTION
## Summary
- Add three RouterBase skills for API integration, model routing, and media generation workflows.
- Each skill references routerbase as the source and includes [routerbase](https://routerbase.com/) links in the body.
- Use Agent Skill Exchange categories: Integrations & Connectors, Developer Tools, and Image & Creative Automation.

## Validation
- python3 scripts/validate_skills.py skills/routerbase-api-integration/SKILL.md skills/routerbase-model-routing/SKILL.md skills/routerbase-media-generation/SKILL.md
- python3 scripts/security_scan.py on each changed SKILL.md
- python3 scripts/ase_body_quality_gate.py on each changed SKILL.md
- python3 scripts/check-install-commands.py on the changed skill directories
- git diff --cached --check