### PR TITLE
feat: add three Claude Code agent skills (self-push, five-element-spec, multi-lens-review)

### DIFF
--- a/skills/five-element-spec/SKILL.md
+++ b/skills/five-element-spec/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: "Five-Element Spec: Scope Before Coding"
+slug: "five-element-spec"
+description: "Translate a vague request or GitHub issue into a concrete, testable spec using five structured elements (problem, scope, acceptance criteria, edge cases, success criterion) before writing any code. Prevents scope creep, PR churn, and mid-implementation pivots."
+category: "Templates & Workflows"
+framework: "Claude Code"
+verification: listed
+source: "https://github.com/TimeToBuildBob/bob"
+---
+
+# Five-Element Spec: Scope Before Coding
+
+Translate a vague request or GitHub issue into a concrete, actionable spec before writing any code.
+
+**Core principle**: If you can't write down what "done" looks like in two sentences, you're not ready to start.
+
+The five-element spec is a lightweight planning format that forces explicit scope boundaries, testable acceptance criteria, and a binary done/not-done signal. It takes 5 minutes for small tasks and prevents hours of rework from scope mismatches, PR churn, and "I thought we wanted X" surprises.
+
+## When to Use
+
+**Always** before:
+- Starting work on a GitHub issue that hasn't been scoped into a task
+- Implementing a feature where acceptance criteria aren't obvious
+- Any task that will take >30 minutes (if you can't spec it in 5 minutes, the scope is unclear)
+- Work that will produce a PR (scope ambiguity creates PR churn)
+
+**Skip** for:
+- Bug fix with a clear reproduction path and obvious scope
+- Mechanical tasks (update a config value, rename a symbol, bump a version)
+- Work already described in a task with a `success_criterion` field
+
+## Installation
+
+### Claude Code
+
+```bash
+cp -R skills/five-element-spec ~/.claude/skills/five-element-spec
+```
+
+Invoke with `/five-element-spec` before starting any non-trivial implementation task.
+
+### Direct repo/manual install
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/five-element-spec ~/.agent-skills/five-element-spec
+```
+
+## The 5-Element Spec
+
+A complete spec answers five questions:
+
+```
+1. PROBLEM — What is broken or missing? What pain does this cause?
+2. SCOPE — What is in scope? What is explicitly out of scope?
+3. ACCEPTANCE CRITERIA — What must be true when this is done? (testable)
+4. EDGE CASES — What unusual inputs or states must be handled?
+5. SUCCESS CRITERION — One sentence: how will we know it's done?
+```
+
+## Spec Template
+
+```markdown
+## Problem
+[1-2 sentences: what is broken/missing and why it matters]
+
+## Scope
+**In scope:**
+- [Specific thing 1]
+- [Specific thing 2]
+
+**Out of scope (explicitly):**
+- [Thing someone might expect but we're not doing]
+
+## Acceptance Criteria
+- [ ] [Testable condition 1 — "X works when Y" or "CI passes for Z"]
+- [ ] [Testable condition 2]
+- [ ] [Testable condition 3]
+
+## Edge Cases
+- [Input or state that needs explicit handling]
+- [Boundary condition]
+
+## Success Criterion
+[One sentence. "When [action], [outcome] happens, verified by [test/check]."]
+```
+
+## From Issue to Spec
+
+### Step 1: Read the issue
+
+```bash
+gh issue view OWNER/REPO#NUM
+```
+
+Look for: what's the complaint? what does the reporter expect? what's missing?
+
+### Step 2: Write the spec
+
+Use the 5-element template above. If you can't fill it in, the issue needs more information — file a comment asking for clarification rather than guessing.
+
+### Step 3: Create a task
+
+Record the spec as a task or ticket in your tracking system of choice, with the `success_criterion` as a first-class field. The binary done/not-done signal from the success criterion is what enables autonomous completion without mid-task re-planning.
+
+## Anti-Patterns
+
+| Anti-Pattern | Fix |
+|---|---|
+| "I'll figure out the scope as I go" | Figure out the scope before you start. Scope discovered mid-implementation causes rework. |
+| "The issue title is clear enough" | Issue titles describe the symptom. Acceptance criteria describe what done looks like. These are different. |
+| "I'll add acceptance criteria to the PR" | PR acceptance criteria are retrospective. Spec first, then implementation, then PR. |
+| "This is small, I don't need a spec" | If it's small enough to skip a spec, it's small enough to write the spec in 3 minutes. Do it. |
+| "The issue has a lot of comments, I'll read them later" | Read them now. The thread often contains the acceptance criteria, edge cases, and out-of-scope decisions already worked out. |
+| Implementing everything in the issue | Issues are wishlists. Specs are commitments. Pick the minimum slice that closes the issue. |
+
+## Red Flags (spec is insufficient)
+
+- Acceptance criteria use words like "better", "improved", "faster" without a measurable threshold
+- No explicit out-of-scope list (scope creep guaranteed)
+- Success criterion references "user will be happy" — not testable
+- Spec lists 8+ acceptance criteria (too big for one task; break it down)
+- Edge cases section is empty (they exist; you just haven't thought about them)
+
+## Outcome
+
+A good spec:
+- Prevents starting the wrong thing
+- Enables autonomous completion without mid-task re-planning
+- Creates clear done/not-done signal for the success criterion field
+- Reduces PR review churn (reviewer and author agree on scope upfront)
+- Makes parallel agent sessions safe (clear scope = no convergent duplicate work)

--- a/skills/five-element-spec/SKILL.md
+++ b/skills/five-element-spec/SKILL.md
@@ -43,7 +43,7 @@ Invoke with `/five-element-spec` before starting any non-trivial implementation 
 
 ```bash
 git clone https://github.com/agentskillexchange/skills.git
-cp -R skills/skills/five-element-spec ~/.agent-skills/five-element-spec
+cp -R skills/five-element-spec ~/.agent-skills/five-element-spec
 ```
 
 ## The 5-Element Spec

--- a/skills/multi-lens-review/SKILL.md
+++ b/skills/multi-lens-review/SKILL.md
@@ -43,7 +43,7 @@ Invoke with `/multi-lens-review` when starting a rigorous PR or diff review.
 
 ```bash
 git clone https://github.com/agentskillexchange/skills.git
-cp -R skills/skills/multi-lens-review ~/.agent-skills/multi-lens-review
+cp -R skills/multi-lens-review ~/.agent-skills/multi-lens-review
 ```
 
 ## Default Lenses

--- a/skills/multi-lens-review/SKILL.md
+++ b/skills/multi-lens-review/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: "Multi-Lens Review"
+slug: "multi-lens-review"
+description: "Review a PR or diff through three independent focused lenses (correctness, security, test coverage), then deduplicate and validate findings before persisting. Catches more real bugs than a single general review pass while producing less noise."
+category: "Code Quality & Review"
+framework: "Claude Code"
+verification: listed
+source: "https://github.com/TimeToBuildBob/bob"
+---
+
+# Multi-Lens Review
+
+Review a diff through multiple focused lenses, then converge the results into one durable output.
+
+**Core principle**: One general review pass catches obvious stuff. Independent focused passes catch the real bugs. But only persist findings that survive deduplication and evidence checks.
+
+A multi-lens review works because each lens creates a different cognitive frame. A security reviewer notices different things than a correctness reviewer, even on the same code. Running three focused passes surfaces the intersection of what each frame misses — which is where real bugs hide.
+
+## When to Use
+
+**Use** when:
+- The diff is non-trivial or risky
+- You need findings, not a vibe-check summary
+- Security, correctness, or missing tests all plausibly matter
+- A single-pass review feels likely to miss something
+
+**Skip** when:
+- The diff is tiny and mechanical
+- The user asked for a lightweight summary, not findings
+- You already have a good human-reviewed finding set and just need to restate it
+
+## Installation
+
+### Claude Code
+
+```bash
+cp -R skills/multi-lens-review ~/.claude/skills/multi-lens-review
+```
+
+Invoke with `/multi-lens-review` when starting a rigorous PR or diff review.
+
+### Direct repo/manual install
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/multi-lens-review ~/.agent-skills/multi-lens-review
+```
+
+## Default Lenses
+
+Use these three unless the task clearly needs a different set:
+
+1. **Correctness** — logic bugs, broken invariants, requirement mismatches
+2. **Security** — unsafe input handling, secret leakage, authz/authn drift
+3. **Test Coverage** — missing regression tests, unverified edge cases
+
+Do not add more lenses in the first pass unless the task explicitly justifies it.
+
+## Inputs To Gather
+
+Before reviewing, collect:
+
+- the diff or changed-file list (`git diff` or `gh pr diff`)
+- the PR / issue description if relevant
+- the repo README, package structure, and recent related changes
+- any existing known issues or findings for this area of the code
+
+If you skip this prep, the lenses will waste time rediscovering repo context.
+
+## Finding Schema
+
+Every lens output must include a structured findings block. This enables deduplication without guesswork:
+
+````md
+## Findings
+
+```json
+[
+  {
+    "category": "security",
+    "severity": "high",
+    "file_path": "src/foo.py",
+    "line": "42-49",
+    "title": "User-controlled input reaches shell=True",
+    "description": "Brief statement of the bug.",
+    "evidence": "Concrete code evidence tied to file + line.",
+    "confidence": 0.82,
+    "fix_hint": "Optional repair hint."
+  }
+]
+```
+````
+
+**No evidence, no finding.** A finding without a specific file path and line reference is an opinion, not a finding.
+
+## Procedure
+
+1. **Prepare shared context**
+   - Create a working directory for this review run (e.g. `review-runs/<repo>/<timestamp>/`)
+   - Write an `input.md` summarizing: what changed, what the PR claims to do, scope
+   - Read it before reviewing — shared context prevents redundant re-discovery
+
+2. **Run the three lens passes**
+   - If the runtime supports parallel subagents, fan them out
+   - Otherwise run sequentially, keeping each pass narrow
+   - Keep each pass narrow: if a security pass starts talking about style, it is drifting
+
+3. **Normalize the findings**
+   - Convert each lens output to the shared schema above
+   - Drop claims without file-specific evidence
+   - Drop findings below confidence 0.6 unless a follow-up pass rescues them
+
+4. **Deduplicate**
+   - Merge same-problem findings across lenses
+   - Keep the strongest wording and highest-confidence evidence
+   - Preserve lens origin as tags, e.g. `lens:security`
+   - Resolve duplicates by majority confidence, not by taking both
+
+5. **Validate survivors**
+   - Re-read the relevant code for each surviving finding
+   - If still uncertain, use a cheap clarification pass before escalating
+   - Only escalate to an expensive deep-review pass for findings that still look material
+
+6. **Persist confirmed survivors**
+   - Record findings in a JSON file or your project's tracking system
+   - Tag with lens origin and review run identifier for traceability
+
+7. **Write the review output**
+   - Present findings ordered by severity (critical → high → medium → low)
+   - State explicitly what you checked and what you did not check
+   - A review that says "I checked X, not Y" is more useful than one that implies completeness
+
+## Suggested Artifact Layout
+
+```txt
+review-runs/<repo_slug>/<run_id>/
+├── input.md            ← shared context for all lenses
+├── lens-correctness.md ← lens 1 findings with JSON block
+├── lens-security.md    ← lens 2 findings with JSON block
+├── lens-test-cov.md    ← lens 3 findings with JSON block
+├── candidates.jsonl    ← deduplicated candidates before validation
+└── summary.md          ← final confirmed findings + review narrative
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Fix |
+|---|---|
+| Run three generic reviews and call them "lenses" | Give each pass a distinct job with an explicit scope constraint. |
+| Persist every raw finding | Only persist confirmed survivors after dedup + validation. |
+| Let every lens re-read the whole repo | Build a tight shared context packet first — one input.md for all lenses. |
+| Add 6-7 lenses immediately | Start with 3. If they miss something important, add a 4th targeted lens. |
+| Use expensive deep-review on every candidate | Cheap validation (re-read the code, spot-check the claim) before escalating. |
+| Treat "no evidence" findings as low-severity | No evidence = not a finding. Demote to a note or discard. |
+
+## Outcome
+
+A good multi-lens review:
+- catches more real bugs than a single pass
+- produces less duplicated noise than ad hoc repeated reviews
+- leaves a durable artifact: the run directory is resumable across sessions
+- reports what was checked, so future reviewers know the coverage boundary

--- a/skills/self-push/SKILL.md
+++ b/skills/self-push/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: "Self-Push: Lazy-Check Before Submitting"
+slug: "self-push"
+description: "Run a structured lazy-check on any significant output before submitting. Forces root-cause analysis, alternative consideration, and outcome verification — especially critical in autonomous runs where no human reviewer will catch lazy shortcuts."
+category: "Code Quality & Review"
+framework: "Claude Code"
+verification: listed
+source: "https://github.com/TimeToBuildBob/bob"
+---
+
+# Self-Push: Lazy-Check Before Submitting
+
+After any significant first-pass output, run a **lazy-check** before submitting: "Is this my best work, or did I take the easy path?"
+
+AI models are trained to produce outputs good enough to avoid correction — this optimizes for satisficing, not maximizing. The model has higher capability than its default mode; it needs a push. In interactive sessions, humans provide that push. In autonomous sessions, this skill is the push.
+
+## When to Use
+
+- After writing any analysis, plan, code, or decision that will ship
+- Especially in autonomous runs — no human reviewer will catch lazy parts
+- When output feels "complete enough" but came together faster than expected
+- Before committing changes where you didn't explicitly reject alternative approaches
+
+**Skip** for: trivial config edits, journal date stamps, mechanical metadata updates.
+
+## Installation
+
+### Claude Code
+
+Copy this skill directory into your agent's skill folder:
+
+```bash
+cp -R skills/self-push ~/.claude/skills/self-push
+```
+
+Then invoke with `/self-push` when you want to trigger a lazy-check.
+
+### Direct repo/manual install
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/self-push ~/.agent-skills/self-push
+```
+
+## The Lazy-Check (3 Questions)
+
+Run these before submitting any significant output:
+
+```
+1. Did I stop at the first plausible explanation, or did I verify the root cause?
+2. Can I name an alternative I considered and rejected, and why?
+3. Did I actually verify the outcome, or am I assuming it worked?
+```
+
+If you can't answer all three with evidence → redo, don't just add words.
+
+## Anti-Rationalization Table
+
+| Rationalization | Reality |
+|---|---|
+| "I'll fix the root cause later — for now let me address the symptom" | Later never comes in autonomous sessions. Fix the root cause now — symptoms are just verification it's still active. |
+| "This analysis is good enough — no one is reviewing it live" | The absence of pushback is why you must push harder. Autonomous runs have no reviewer; the quality burden is entirely on your own lazy-check. |
+| "I already checked, no need to double-check" | Single checks miss subtle state: dirty submodules, uncommitted worktrees, unseen stderr, false negatives from stale caches. |
+| "The first approach worked, so it's the best one" | First plausible solution is rarely optimal. List 2-3 alternatives before committing. If you can't name a trade-off you rejected, you didn't consider alternatives. |
+| "This is just a quick fix — not worth deep analysis" | Quick fixes that skip root-cause analysis compound into tech-debt avalanches. If it's worth doing, it's worth understanding why it needed doing. |
+| "Tests pass, so the code is correct" | Passing tests don't catch architecture drift, silent edge cases, security regressions, or gaps in the tests themselves. |
+| "I'll explain the reasoning in the commit message" | Commit messages say *what* changed; they rarely capture *why I chose this over the alternative I rejected*. Write the trade-off decision before committing. |
+| "I already ran that command once — it'll be the same result" | Filesystem state may have changed. Commands with side effects produce different results on subsequent runs. Re-verify if the outcome matters. |
+
+## Red Flags
+
+- Can't articulate what alternatives were considered and rejected
+- "Fixing" a symptom without tracing it to its root cause
+- Commands described as "verified" but no output evidence in the conversation
+- Commit messages that describe *what* changed but not *why this approach*
+- Output feels structurally correct but thin — surface-level engagement
+- Same command run twice without intervening state changes
+- Bug fixes without a reproduction path or regression test
+
+## Verification Checklist
+
+Before every significant commit:
+
+```
+- [ ] Root cause identified (not just symptom)
+- [ ] At least one alternative considered and rejected with reason
+- [ ] All asserted outcomes actually verified (not assumed)
+- [ ] No command re-run without intervening state change
+- [ ] If a bug was fixed, there's a reproduction path or regression test
+- [ ] The commit message captures the *why*, not just the *what*
+```
+
+## Why This Matters
+
+The training objective for LLMs optimizes for "produce output good enough to avoid correction" — not "maximize quality." That gradient is fine when a human is in the loop. In autonomous agents, there is no correction signal until the work has already shipped. This skill injects an explicit quality gate before submission, shifting the effective optimization target from "avoid correction" to "maximize correctness."

--- a/skills/self-push/SKILL.md
+++ b/skills/self-push/SKILL.md
@@ -39,7 +39,7 @@ Then invoke with `/self-push` when you want to trigger a lazy-check.
 
 ```bash
 git clone https://github.com/agentskillexchange/skills.git
-cp -R skills/skills/self-push ~/.agent-skills/self-push
+cp -R skills/self-push ~/.agent-skills/self-push
 ```
 
 ## The Lazy-Check (3 Questions)


### PR DESCRIPTION
## Summary

Three generic Claude Code agent skills extracted and adapted from the [TimeToBuildBob/bob](https://github.com/TimeToBuildBob/bob) autonomous agent workspace, where they've been battle-tested across hundreds of autonomous sessions.

### `self-push` — Lazy-check before submitting

Forces root-cause identification, alternative consideration, and outcome verification before any significant output ships. Addresses the LLM satisficing problem: models are trained to produce output good enough to avoid correction, not to maximize quality. In autonomous runs without a human reviewer, this skill is the correction signal.

- 3-question lazy-check (root cause? alternative rejected? outcome verified?)
- Anti-rationalization table (8 common escape routes + why they're wrong)
- Verification checklist for commits

### `five-element-spec` — Scope before coding

Translates vague requests or GitHub issues into a concrete 5-element spec (problem, scope, acceptance criteria, edge cases, success criterion) before writing any code. The binary done/not-done success criterion enables autonomous completion without mid-task re-planning.

- 5-element template with fill-in-the-blank format
- Anti-patterns table (6 common spec failures)
- Red flags checklist for insufficient specs

### `multi-lens-review` — Three-pass PR review with deduplication

Reviews a diff through three independent focused lenses (correctness, security, test coverage), deduplicates findings across lenses, validates survivors, and presents results by severity. Catches more real bugs than a single general review pass while producing less noise.

- Structured finding schema (category, severity, file, line, evidence, confidence)
- Explicit deduplication procedure
- Suggested artifact layout for resumable review runs

## Test Plan

- [ ] Each SKILL.md has required frontmatter fields (name, slug, description, category, framework, verification, source)
- [ ] Slug matches directory name in each case
- [ ] Content is self-contained (no internal path references, no project-specific tooling)
- [ ] Installation sections present for each skill