### PR TITLE
test: preserve Installation quality regressions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,8 @@ on:
       - 'skills/**'
       - 'scripts/validate-skill.sh'
       - 'scripts/validate_skills.py'
+      - 'scripts/ase_body_quality_gate.py'
+      - 'scripts/test_body_quality_fixtures.py'
       - 'scripts/security_scan.py'
       - 'scripts/test_security_patterns.py'
       - 'scripts/smoke-agent-endpoints.py'
@@ -19,6 +21,8 @@ on:
       - 'skills/**'
       - 'scripts/validate-skill.sh'
       - 'scripts/validate_skills.py'
+      - 'scripts/ase_body_quality_gate.py'
+      - 'scripts/test_body_quality_fixtures.py'
       - 'scripts/security_scan.py'
       - 'scripts/test_security_patterns.py'
       - 'scripts/smoke-agent-endpoints.py'
@@ -51,6 +55,9 @@ jobs:
           else
             echo "No changed skill files to validate."
           fi
+
+      - name: Test generated Installation body quality
+        run: python3 scripts/test_body_quality_fixtures.py
 
       - name: Test executable security patterns
         run: python3 scripts/test_security_patterns.py

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,6 +38,21 @@ python3 scripts/validate_skills.py --all --github-annotations --quiet
 
 **Exit codes:** `0` on pass, `1` on validation failure, `2` when PyYAML is unavailable.
 
+### `ase_body_quality_gate.py` and `test_body_quality_fixtures.py`
+
+The body-quality gate detects malformed generated Installation sections, copied
+README navigation, and stale numeric GitHub-star claims. The fixture suite keeps
+known extraction failures and clean installation examples as durable regression
+coverage:
+
+```bash
+python3 scripts/test_body_quality_fixtures.py
+python3 scripts/ase_body_quality_gate.py --all
+```
+
+CI runs the fixture suite independently from the full catalog validator so the
+known failure shapes remain covered without rewriting existing skill bodies.
+
 ### `security_scan.py` and `test_security_patterns.py`
 
 Executable security pattern scanner and fixture test suite for the trust layer.

--- a/scripts/ase_body_quality_gate.py
+++ b/scripts/ase_body_quality_gate.py
@@ -2,8 +2,8 @@
 """Fail-closed body quality gate for security-reviewed ASE skills.
 
 This catches severe extraction/provenance defects that the schema validator does
-not see: upstream table-of-contents fragments copied into skill bodies and stale
-numeric GitHub-star claims in prose.
+not see: upstream table-of-contents fragments copied into skill bodies, malformed
+Installation sections, and stale numeric GitHub-star claims in prose.
 """
 
 from __future__ import annotations
@@ -32,6 +32,50 @@ NUMBERED_TOC_RE = re.compile(r"^\s*[-*]\s+\d+(?:\.\d+)+\.?\s+[A-Z][^:]{0,90}\s*$
 DOTTED_TOC_RE = re.compile(r"^\s*(?:[-*]\s*)?\S.{0,120}?\.{3,}\s*\d{1,4}\s*$")
 FORMATTED_TOC_RE = re.compile(r"^\s*[-*]\s+(?:\*\*)?table of contents(?:\*\*)?\s*:", re.I)
 HEADING_BULLET_RE = re.compile(r"^\s*[-*]\s+(?:#+\s*)?(?P<label>[A-Z][A-Za-z0-9 /&()'.,:-]{2,90})\s*$")
+SAFE_INSTALL_FALLBACK = "No source-backed install or usage instructions could be extracted automatically."
+RAW_INSTALL_FRAGMENT_RE = re.compile(
+    r"<\s*/?\s*(?:details|summary|img|table|thead|tbody|tr|td|th)\b|"
+    r"!\[[^\]]*(?:badge|shield|build|coverage|version)[^\]]*\]\([^)]*(?:shields\.io|badge|svg)[^)]*\)",
+    re.I,
+)
+COMMAND_START_RE = re.compile(
+    r"^(?:\$+\s*)?(?:brew|npm|pnpm|yarn|npx|pipx?|uv|cargo|go\s+install|"
+    r"docker(?:\s+compose)?|git\s+clone|make|cmake|conda|gem|composer|python\s+-m\s+pip)\b",
+    re.I,
+)
+INSTALL_COMMAND_RE = re.compile(
+    r"^(?:\$+\s*)?(?:"
+    r"brew\s+install\b|npm\s+(?:install|i|add)\b|pnpm\s+(?:add|install)\b|"
+    r"yarn\s+(?:add|install)\b|npx\b|pipx\s+install\b|pip\s+install\b|"
+    r"python\s+-m\s+pip\s+install\b|uv\s+(?:tool\s+install|add|pip\s+install)\b|"
+    r"cargo\s+install\b|go\s+install\b|gem\s+install\b|composer\s+(?:require|install)\b|"
+    r"conda\s+install\b|brew\s+tap\b|git\s+clone\b|docker\s+(?:pull|compose\s+up)\b"
+    r")",
+    re.I,
+)
+NON_INSTALL_COMMAND_RE = re.compile(
+    r"^(?:\$+\s*)?(?:"
+    r"npm\s+(?:run\s+)?(?:test|bench|benchmark|build|lint|dev)\b|"
+    r"pnpm\s+(?:test|bench|benchmark|build|lint|dev)\b|"
+    r"yarn\s+(?:test|bench|benchmark|build|lint|dev)\b|"
+    r"pytest\b|make\s+(?:test|bench|benchmark|build|lint|clean|uninstall)\b|"
+    r"cargo\s+(?:test|bench|build)\b|go\s+test\b|"
+    r"pip\s+uninstall\b|npm\s+(?:uninstall|remove|rm)\b|brew\s+uninstall\b"
+    r")",
+    re.I,
+)
+TRUNCATED_INSTALL_RE = re.compile(r"(?:\\\s*$|&&\s*$|\|\|\s*$|\|\s*$|;\s*$)", re.I)
+PROSE_AS_COMMAND_RE = re.compile(
+    r"^(?:make mistakes|click here|learn more|read more|see below|table of contents|"
+    r"contents|installation|features?|screenshots?|badges?)(?:\.|\s|$)",
+    re.I,
+)
+MANUAL_SETUP_RE = re.compile(
+    r"\b(?:configure|set up|setup|create|copy|add|enable|install|place|download|follow|review)\b"
+    r".*\b(?:env(?:ironment)? variable|api key|credential|token|config|configuration|workspace|"
+    r"skill|extension|plugin|package|upstream|source|docs?|instructions?|directory|folder|destination)\b",
+    re.I,
+)
 
 
 def parse_frontmatter(text: str) -> tuple[dict[str, Any], int]:
@@ -86,6 +130,151 @@ def structured_stars(fields: dict[str, Any]) -> int | None:
         return top
     tool = fields.get("tool_ecosystem") if isinstance(fields.get("tool_ecosystem"), dict) else {}
     return as_int(tool.get("github_stars"))
+
+
+def normalize_source_terms(fields: dict[str, Any], path: Path) -> set[str]:
+    terms: set[str] = set()
+    for key in ("name", "slug", "source"):
+        value = str(fields.get(key) or "").lower()
+        if value:
+            terms.add(value)
+            for part in re.split(r"[^a-z0-9@._/-]+", value):
+                part = part.strip("/")
+                if part.endswith(".git"):
+                    part = part[:-4]
+                if len(part) >= 3:
+                    terms.add(part)
+    terms.add(path.parent.name.lower())
+    tool = fields.get("tool_ecosystem") if isinstance(fields.get("tool_ecosystem"), dict) else {}
+    for key in ("github_repo", "npm_package", "parent_repo"):
+        value = str(tool.get(key) or "").lower()
+        if value:
+            terms.add(value)
+            terms.update(part for part in re.split(r"[/\s]+", value) if len(part) >= 3)
+    ignored = {"skill", "agent", "agents", "github", "main", "master", "https", "http", "com", "www"}
+    return {term for term in terms if term not in ignored}
+
+
+def clean_install_line(line: str) -> str:
+    line = line.strip()
+    line = re.sub(r"^\s*(?:[-*+]|\d+[.)])\s+", "", line)
+    line = re.sub(r"^\s*(?:\$+\s*)", "", line)
+    line = line.strip("` \t")
+    line = re.sub(r"\s+", " ", line).strip()
+    if re.fullmatch(
+        r"(?:bash|sh|shell|console|terminal|text|markdown|md|html|json|yaml|yml|python|js|ts)",
+        line,
+        re.I,
+    ):
+        return ""
+    return line
+
+
+def installation_section(text: str) -> str:
+    match = re.search(r"^## Installation\s*\n([\s\S]*?)(?=^##\s+|\Z)", text, re.M)
+    return match.group(1).strip() if match else ""
+
+
+def command_mentions_source(command: str, terms: set[str]) -> bool:
+    command_l = command.lower()
+    if command_l.startswith("git clone "):
+        return True
+    return any(term and term in command_l for term in terms)
+
+
+def installation_issues(text: str, fields: dict[str, Any], path: Path) -> list[dict[str, Any]]:
+    section = installation_section(text)
+    if not section:
+        return [{"line": 0, "text": "", "reason": "missing Installation section"}]
+
+    verification = str(fields.get("verification") or "").strip()
+    if SAFE_INSTALL_FALLBACK in section:
+        if verification == "listed":
+            return []
+        return [{
+            "line": 0,
+            "text": SAFE_INSTALL_FALLBACK,
+            "reason": "safe fallback requires verification listed",
+        }]
+
+    issues: list[dict[str, Any]] = []
+    if RAW_INSTALL_FRAGMENT_RE.search(section) or re.search(r"<\s*a\b|<\s*/?\s*p\b|<\s*/?\s*div\b", section, re.I):
+        issues.append({"line": 0, "text": "raw HTML or badge markup", "reason": "raw README/HTML fragment in Installation section"})
+    if re.search(r"(?:shields\.io|badge\.svg|coverage\.svg)", section, re.I):
+        issues.append({"line": 0, "text": "badge markup", "reason": "badge markup in Installation section"})
+
+    terms = normalize_source_terms(fields, path)
+    actionable = False
+    install_command = False
+    non_install_commands: list[str] = []
+    unrelated_commands: list[str] = []
+    prose_commands: list[str] = []
+    truncated: list[str] = []
+    duplicate_commands: list[str] = []
+    seen_commands: set[str] = set()
+    marketing_lines = 0
+    meaningful_lines = 0
+
+    for original in section.splitlines():
+        line = clean_install_line(original)
+        if not line or line.lower().startswith("source: "):
+            continue
+        meaningful_lines += 1
+        low = line.lower()
+        if TRUNCATED_INSTALL_RE.search(line):
+            truncated.append(line)
+        if PROSE_AS_COMMAND_RE.match(low):
+            prose_commands.append(line)
+        if re.search(
+            r"\b(?:screenshot|feature|features|powered by|star us|community|showcase|benchmark results?|quick start)\b",
+            low,
+            re.I,
+        ):
+            marketing_lines += 1
+        if COMMAND_START_RE.search(line):
+            command_key = re.sub(r"\s+", " ", line.rstrip("\\").strip()).lower()
+            if command_key in seen_commands:
+                duplicate_commands.append(line)
+            seen_commands.add(command_key)
+            if NON_INSTALL_COMMAND_RE.search(line):
+                non_install_commands.append(line)
+                continue
+            if INSTALL_COMMAND_RE.search(line):
+                install_command = True
+                if command_mentions_source(line, terms):
+                    actionable = True
+                else:
+                    unrelated_commands.append(line)
+                continue
+            prose_commands.append(line)
+            continue
+        if re.search(
+            r"\b(?:clone|install|copy|add|configure|bootstrap|documented installer|marketplace|mcp server)\b",
+            line,
+            re.I,
+        ) and command_mentions_source(line, terms):
+            actionable = True
+            continue
+        if MANUAL_SETUP_RE.search(line):
+            actionable = True
+
+    if re.search(r"\[[^\]]+\]\(#[^)]+\)", section) and not actionable:
+        issues.append({"line": 0, "text": "TOC links", "reason": "only TOC/navigation links in Installation section"})
+    if truncated:
+        issues.append({"line": 0, "text": truncated[0], "reason": "truncated or incomplete install line"})
+    if duplicate_commands:
+        issues.append({"line": 0, "text": duplicate_commands[0], "reason": "duplicate install command"})
+    if prose_commands:
+        issues.append({"line": 0, "text": prose_commands[0], "reason": "prose or non-install text classified as command"})
+    if non_install_commands and not install_command and not actionable:
+        issues.append({"line": 0, "text": non_install_commands[0], "reason": "only uninstall/test/benchmark/build commands found"})
+    if unrelated_commands and not actionable:
+        issues.append({"line": 0, "text": unrelated_commands[0], "reason": "package/tool command is not source-aligned"})
+    if meaningful_lines and marketing_lines == meaningful_lines:
+        issues.append({"line": 0, "text": "marketing-only install section", "reason": "only marketing/features/screenshots/badges found"})
+    if not actionable and not issues:
+        issues.append({"line": 0, "text": section[:160], "reason": "no actionable installation command or manual setup instruction"})
+    return issues
 
 
 def star_claim_value(match: re.Match[str]) -> int:
@@ -179,6 +368,7 @@ def scan_file(path: Path) -> dict[str, Any]:
         "slug": path.parent.name,
         "verification": verification,
         "toc_fragments": toc_fragments,
+        "installation_issues": installation_issues(text, fields, path),
         "stale_star_claims": star_claims,
         "markdown_heading_bullet_warnings": heading_warnings,
     }

--- a/scripts/test_body_quality_fixtures.py
+++ b/scripts/test_body_quality_fixtures.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Regression fixtures for generated SKILL.md Installation quality."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from ase_body_quality_gate import scan_file
+
+
+def skill_markdown(slug: str, verification: str, installation: str, *, source: str, repo: str = "") -> str:
+    tool_ecosystem = f'\ntool_ecosystem:\n  github_repo: "{repo}"' if repo else ""
+    return f'''---
+name: "Fixture {slug}"
+slug: "{slug}"
+description: "A focused body-quality regression fixture for installation guidance."
+category: "Developer Tools"
+framework: "Multi-Framework"
+verification: "{verification}"
+source: "{source}"{tool_ecosystem}
+---
+
+# Fixture {slug}
+
+## Installation
+
+{installation.strip()}
+
+## Usage
+
+Run the documented workflow in a sandbox and verify its output.
+'''
+
+
+CASES = [
+    {
+        "name": "elves_prose_as_install_command_security_reviewed_fails",
+        "slug": "elves-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/aigorahub/elves",
+        "repo": "aigorahub/elves",
+        "installation": "- make mistakes. Always review the PR before merging.",
+        "pass": False,
+        "reason": "prose or non-install text classified as command",
+    },
+    {
+        "name": "gaai_duplicate_truncated_details_security_reviewed_fails",
+        "slug": "gaai-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/Fr-e-d/GAAI-framework",
+        "repo": "Fr-e-d/GAAI-framework",
+        "installation": """- git clone https://github.com/Fr-e-d/GAAI-framework.git /tmp/gaai
+- git clone https://github.com/Fr-e-d/GAAI-framework.git /tmp/gaai
+- git clone https://github.com/Fr-e-d/GAAI-framework.git /tmp/gaai && \\
+- <details open>""",
+        "pass": False,
+        "reason": "raw README/HTML fragment in Installation section",
+    },
+    {
+        "name": "honey_unrelated_packages_security_reviewed_fails",
+        "slug": "honey-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/Green-PT/honey-for-devs",
+        "repo": "Green-PT/honey-for-devs",
+        "installation": """- npx pxpipe-proxy export --json src/
+- pip install ecologits""",
+        "pass": False,
+        "reason": "package/tool command is not source-aligned",
+    },
+    {
+        "name": "hcom_build_test_uninstall_only_security_reviewed_fails",
+        "slug": "hcom-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/aannoo/hcom",
+        "repo": "aannoo/hcom",
+        "installation": """- brew uninstall hcom
+- cargo build
+- cargo test""",
+        "pass": False,
+        "reason": "only uninstall/test/benchmark/build commands found",
+    },
+    {
+        "name": "socraticode_badges_features_links_security_reviewed_fails",
+        "slug": "socraticode-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/giancarloerra/SocratiCode",
+        "repo": "giancarloerra/SocratiCode",
+        "installation": """- <a href=\"https://nodejs.org/\"><img src=\"https://img.shields.io/badge/node-18-green.svg\"></a>
+- Features: private and local by default
+- [Quick Start](#quick-start)""",
+        "pass": False,
+        "reason": "raw README/HTML fragment in Installation section",
+    },
+    {
+        "name": "stitch_valid_commands_with_details_security_reviewed_fails",
+        "slug": "stitch-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/google-labs-code/stitch-skills",
+        "repo": "google-labs-code/stitch-skills",
+        "installation": """- npx skills add google-labs-code/stitch-skills
+- <details open>""",
+        "pass": False,
+        "reason": "raw README/HTML fragment in Installation section",
+    },
+    {
+        "name": "valid_npm_install_security_reviewed_passes",
+        "slug": "widget-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/acme/widget",
+        "repo": "acme/widget",
+        "installation": "```bash\nnpm install widget\n```",
+        "pass": True,
+    },
+    {
+        "name": "valid_pip_uv_install_security_reviewed_passes",
+        "slug": "widget-cli-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/acme/widget-cli",
+        "repo": "acme/widget-cli",
+        "installation": "```bash\nuv tool install widget-cli\n```",
+        "pass": True,
+    },
+    {
+        "name": "valid_git_clone_copy_destination_security_reviewed_passes",
+        "slug": "clone-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/acme/clone-tool",
+        "repo": "acme/clone-tool",
+        "installation": """```bash
+git clone https://github.com/acme/clone-tool.git
+```
+Copy the configuration file into your agent workspace.""",
+        "pass": True,
+    },
+    {
+        "name": "valid_manual_setup_no_shell_security_reviewed_passes",
+        "slug": "manual-setup-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/acme/manual-setup",
+        "repo": "acme/manual-setup",
+        "installation": "Copy the plugin folder into your agent workspace and configure the API key as an environment variable.",
+        "pass": True,
+    },
+    {
+        "name": "listed_safe_fallback_passes",
+        "slug": "listed-fallback-install-quality-fixture",
+        "verification": "listed",
+        "source": "https://github.com/acme/listed-fallback",
+        "repo": "acme/listed-fallback",
+        "installation": "No source-backed install or usage instructions could be extracted automatically. Review the upstream project before running this skill in a sensitive workflow.",
+        "pass": True,
+    },
+]
+
+
+def main() -> int:
+    mismatches: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="ase-body-quality-fixtures-") as temp:
+        root = Path(temp)
+        for case in CASES:
+            path = root / case["slug"] / "SKILL.md"
+            path.parent.mkdir(parents=True)
+            path.write_text(
+                skill_markdown(
+                    case["slug"],
+                    case["verification"],
+                    case["installation"],
+                    source=case["source"],
+                    repo=case["repo"],
+                ),
+                encoding="utf-8",
+            )
+            report = scan_file(path)
+            issues = report["installation_issues"]
+            passed = not issues
+            expected = case["pass"]
+            print(f'{case["name"]}: {"PASS" if passed else "FAIL"} (expected {"PASS" if expected else "FAIL"})')
+            if passed != expected:
+                mismatches.append(f'{case["name"]}: expected pass={expected}, issues={issues}')
+                continue
+            expected_reason = case.get("reason")
+            if expected_reason and expected_reason not in {issue["reason"] for issue in issues}:
+                mismatches.append(f'{case["name"]}: missing reason {expected_reason!r}, issues={issues}')
+
+    if mismatches:
+        print("\nFixture mismatches:")
+        for mismatch in mismatches:
+            print(f"- {mismatch}")
+        return 1
+    print(f"\nPASS: {len(CASES)}/{len(CASES)} body-quality fixture(s) matched expected results")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds durable Installation-quality detection and an 11-case regression suite for Elves, GAAI, Honey, hcom, SocratiCode, Stitch Skills, and five clean controls. Wires the suite into Validate Skills CI and documents the command. Root cause: the prior files were created in a disposable Sync checkout and were never committed. Validation: Python compile passed; fixtures 11/11; catalog validation 2788/2788 with 6 warnings; 79 security fixtures passed; full security scan found 0 issues; git diff check passed. This PR does not rewrite skill bodies, run GitHub Sync, or modify WordPress.