### PR TITLE
Fix generated Installation wrapper neutrality

### DIFF
--- a/scripts/ase_body_quality_gate.py
+++ b/scripts/ase_body_quality_gate.py
@@ -33,6 +33,12 @@ DOTTED_TOC_RE = re.compile(r"^\s*(?:[-*]\s*)?\S.{0,120}?\.{3,}\s*\d{1,4}\s*$")
 FORMATTED_TOC_RE = re.compile(r"^\s*[-*]\s+(?:\*\*)?table of contents(?:\*\*)?\s*:", re.I)
 HEADING_BULLET_RE = re.compile(r"^\s*[-*]\s+(?:#+\s*)?(?P<label>[A-Z][A-Za-z0-9 /&()'.,:-]{2,90})\s*$")
 SAFE_INSTALL_FALLBACK = "No source-backed install or usage instructions could be extracted automatically."
+GENERATED_INSTALL_WRAPPER_LINES = {
+    "Use the upstream install or setup path that matches your environment:",
+    "Install or set up from the source-backed instructions:",
+    "Requirements and caveats from upstream:",
+    "Basic usage or getting-started notes:",
+}
 RAW_INSTALL_FRAGMENT_RE = re.compile(
     r"<\s*/?\s*(?:details|summary|img|table|thead|tbody|tr|td|th)\b|"
     r"!\[[^\]]*(?:badge|shield|build|coverage|version)[^\]]*\]\([^)]*(?:shields\.io|badge|svg)[^)]*\)",
@@ -170,6 +176,10 @@ def clean_install_line(line: str) -> str:
     return line
 
 
+def is_generated_install_wrapper(line: str) -> bool:
+    return line.strip() in GENERATED_INSTALL_WRAPPER_LINES
+
+
 def installation_section(text: str) -> str:
     match = re.search(r"^## Installation\s*\n([\s\S]*?)(?=^##\s+|\Z)", text, re.M)
     return match.group(1).strip() if match else ""
@@ -219,6 +229,8 @@ def installation_issues(text: str, fields: dict[str, Any], path: Path) -> list[d
         line = clean_install_line(original)
         if not line or line.lower().startswith("source: "):
             continue
+        if is_generated_install_wrapper(line):
+            continue
         meaningful_lines += 1
         low = line.lower()
         if TRUNCATED_INSTALL_RE.search(line):
@@ -249,7 +261,7 @@ def installation_issues(text: str, fields: dict[str, Any], path: Path) -> list[d
             prose_commands.append(line)
             continue
         if re.search(
-            r"\b(?:clone|install|copy|add|configure|bootstrap|documented installer|marketplace|mcp server)\b",
+            r"\b(?:clone|install|add|configure|bootstrap|documented installer|marketplace|mcp server)\b",
             line,
             re.I,
         ) and command_mentions_source(line, terms):

--- a/scripts/test_body_quality_fixtures.py
+++ b/scripts/test_body_quality_fixtures.py
@@ -74,9 +74,15 @@ CASES = [
         "verification": "security_reviewed",
         "source": "https://github.com/aannoo/hcom",
         "repo": "aannoo/hcom",
-        "installation": """- brew uninstall hcom
-- cargo build
-- cargo test""",
+        "installation": """Use the upstream install or setup path that matches your environment:
+
+- brew uninstall hcom # or: rm $(which hcom)
+- cargo build && cargo test
+
+Basic usage or getting-started notes:
+- Use it to coordinate pipelines, run different AI CLIs as each other's subagents, or just instead of copy-paste.
+- Terminal 1:
+- hcom claude # codex / gemini / opencode / kilo / pi / omp / agy / cursor-agent / kimi / copilot""",
         "pass": False,
         "reason": "only uninstall/test/benchmark/build commands found",
     },
@@ -102,6 +108,19 @@ CASES = [
 - <details open>""",
         "pass": False,
         "reason": "raw README/HTML fragment in Installation section",
+    },
+    {
+        "name": "valid_wrapper_brew_install_security_reviewed_passes",
+        "slug": "hcom-valid-wrapper-install-quality-fixture",
+        "verification": "security_reviewed",
+        "source": "https://github.com/aannoo/hcom",
+        "repo": "aannoo/hcom",
+        "installation": """Use the upstream install or setup path that matches your environment:
+
+```bash
+brew install hcom
+```""",
+        "pass": True,
     },
     {
         "name": "valid_npm_install_security_reviewed_passes",


### PR DESCRIPTION
## Summary
- treat generated Installation wrapper/label lines as neutral formatting
- keep copy-specific setup actionability on the stricter manual setup detector instead of source-term prose matching
- update the hcom regression fixture to match the production-generated wrapper and combined command shape
- add a positive wrapper + `brew install hcom` control

## Verification
- `python3 -m py_compile scripts/ase_body_quality_gate.py scripts/test_body_quality_fixtures.py`
- `python3 scripts/test_body_quality_fixtures.py` -> 12/12
- actual hcom before: exit 0
- actual hcom after: exit 1
- positive wrapper + brew install: exit 0
- six known malformed files: all exit 1
- `python3 scripts/ase_body_quality_gate.py --all --quiet` -> exit 0
- `python3 scripts/validate_skills.py --all --quiet` -> 2789/2789 passed
- `python3 scripts/test_security_patterns.py` -> 79 fixtures passed
- `python3 scripts/security_scan.py skills --github-annotations --quiet` -> PASS, 0 findings
- `git diff --check`

