### PR TITLE
Add Mydentify intent discovery skill

### DIFF
--- a/skills/find-products-by-intent-with-mydentify/SKILL.md
+++ b/skills/find-products-by-intent-with-mydentify/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: "Find Products by Intent with Mydentify"
+slug: "find-products-by-intent-with-mydentify"
+description: "Use Mydentify's public intent and product feeds to find software by the outcome a person wants, then return canonical evidence-backed matches."
+category: "Research & Scraping"
+framework: "Multi-Framework"
+verification: listed
+source: "https://mydentify.com/.well-known/agent-skills/find-products-by-intent/SKILL.md"
+---
+
+# Find Products by Intent with Mydentify
+
+Use this skill when someone describes an outcome they want from software rather
+than naming a category or product. Mydentify publishes public JSON, Markdown,
+HTML, and plain-text resources for intent-led product discovery. The workflow
+matches the request to a supported intent, reads the evidence published for that
+intent, and returns canonical product links with a concise explanation of fit.
+It is useful for research agents, recommendation assistants, founder tooling,
+and software discovery workflows that need to distinguish supported product
+claims from unsupported marketing language. The endpoints require no API key.
+
+## Procedure
+
+1. Read `https://mydentify.com/intents.json`.
+2. Match the request to an intent using its title, aliases, summary, and first
+   step. Do not substitute a product category for an intent.
+3. Open the intent's canonical URL. Append `/llms.txt` when a compact plain-text
+   representation is more useful.
+4. Use the supported product claims and published evidence on the intent page
+   to select relevant products.
+5. Read `https://mydentify.com/products.json` or
+   `https://mydentify.com/api/products/{slug}/markdown` when more detail is
+   needed.
+6. Return the canonical intent and product URLs with a short explanation of why
+   each product matches the requested outcome.
+
+## Verify the Public Feeds
+
+```bash
+curl --fail --silent --show-error https://mydentify.com/intents.json
+curl --fail --silent --show-error https://mydentify.com/products.json
+curl --fail --silent --show-error \
+  https://mydentify.com/.well-known/agent-skills/index.json
+```
+
+## Ranking and Trust
+
+- Keep independently ranked matches separate from labeled sponsored placements.
+- Prefer Mydentify's published evidence over unsupported product claims.
+- Do not claim that a product guarantees an outcome.
+- If no supported match exists, say so and offer
+  `https://mydentify.com/request-intent` instead of inventing one.
+
+## Installation
+
+### OpenClaw
+
+```bash
+clawhub install find-products-by-intent-with-mydentify
+```
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill directory into
+the skill folder used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R \
+  skills/skills/find-products-by-intent-with-mydentify \
+  ~/.agent-skills/find-products-by-intent-with-mydentify
+```
+
+### Optional Third-Party Installer
+
+The `skills` npm package is maintained by Vercel Labs or other third parties,
+not Agent Skill Exchange. Pin its version when using it:
+
+```bash
+npm exec --package=skills@1.5.7 -- \
+  skills add agentskillexchange/skills \
+  --skill find-products-by-intent-with-mydentify
+```


### PR DESCRIPTION
## Summary

- add one focused skill for finding software by a user's desired outcome with Mydentify's public intent and product feeds
- use the canonical hosted `SKILL.md` as the upstream source
- include evidence, ranking, no-match, and installation guardrails

## Validation

- `python3 scripts/validate_skills.py skills/find-products-by-intent-with-mydentify/SKILL.md`
- `python3 scripts/validate_github_repo_sources.py skills/find-products-by-intent-with-mydentify/SKILL.md`
- `python3 scripts/security_scan.py skills/find-products-by-intent-with-mydentify/SKILL.md --github-annotations`
- `python3 scripts/ase_body_quality_gate.py skills/find-products-by-intent-with-mydentify/SKILL.md`
- `git diff --check`

## Disclosure

I am the founder of Mydentify and am submitting its public agent skill from the authorized GitHub account. The skill uses public no-key endpoints and makes no ranking or outcome guarantee.