### PR TITLE
feat: add social-corpus-harvest skill

### DIFF
--- a/skills/social-corpus-harvest/SKILL.md
+++ b/skills/social-corpus-harvest/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: "Social Corpus Harvest"
+slug: "social-corpus-harvest"
+description: "Collects a human-verified person, creator, brand, or organization's self-authored public Xiaohongshu, Douyin, and Weibo posts through OpenCLI into a local Markdown dataset with stable source URLs, author checks, capture timestamps, and a provenance manifest. Use for public-content archives, knowledge bases, RAG ingestion, content audits, research datasets, and consented AI data preparation."
+category: "Research & Scraping"
+framework: "Codex"
+verification: listed
+source: "https://github.com/yuwanpai2004-create/codex-skills"
+---
+
+# Social Corpus Harvest
+
+Social Corpus Harvest is a reusable Codex workflow backed by the open-source
+`yuwanpai2004-create/codex-skills` repository. It combines Agent Reach, OpenCLI,
+the official OpenCLI Chrome extension, and bundled Python orchestration to
+collect public posts from Xiaohongshu, Douyin, and Weibo. The workflow verifies
+the target account before collection, strips temporary signed URL parameters,
+checks authorship where the platform adapter permits it, and writes one
+Markdown file per post plus a machine-readable source manifest.
+
+Use it when scattered public posts need to become a traceable local archive,
+knowledge base, RAG source, content-analysis dataset, migration package, or
+consented AI persona/training candidate set. Do not use it to guess accounts,
+collect private content, copy comments or fan edits, bypass platform
+challenges, or obtain passwords, cookies, session tokens, or CAPTCHA answers.
+Downloading or transcribing audio/video requires a separate user decision.
+Collection does not itself grant republication, commercial-use, or
+model-training rights.
+
+## Installation
+
+### Direct repository install
+
+```bash
+git clone https://github.com/yuwanpai2004-create/codex-skills.git
+cp -R codex-skills/skills/social-corpus-harvest ~/.codex/skills/
+```
+
+### Optional third-party installer
+
+The `skills` npm package is maintained by a third party. Pin the version when
+using it:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add \
+  yuwanpai2004-create/codex-skills \
+  --skill social-corpus-harvest \
+  -a codex
+```
+
+## Prerequisites
+
+- Python 3.10 or newer.
+- Chrome controlled by the user.
+- User approval before installing user-local Agent Reach, Node.js, or OpenCLI
+  dependencies.
+- The official OpenCLI Chrome extension and an explicit user login for each
+  selected platform.
+- Exact profile links and human-recorded account-verification evidence.
+
+The bootstrap never uses `sudo`, never stores browser credentials, and fails
+closed when the Browser Bridge or required adapter commands are unavailable.
+
+## Workflow
+
+1. Run `python scripts/bootstrap.py check --json`.
+2. With user approval, run `python scripts/bootstrap.py install` if required.
+3. Connect the official extension and let the user complete platform login.
+4. Create `corpus/social_profiles.json` with
+   `scripts/init_profile_map.py`, including verifier and evidence fields.
+5. Run `scripts/harvest_social_corpus.py <OUT_DIR> --name <SUBJECT> --dry-run`.
+6. Review the planned platforms and limits, then rerun without `--dry-run`.
+7. Resolve every failed platform, spot-check Markdown against source URLs, and
+   retain `corpus/public_social/source_manifest.json` with the dataset.
+
+The complete upstream skill includes setup guidance, dependency pins, profile
+schema documentation, collection scripts, and recovery behavior.


### PR DESCRIPTION
## What this skill does

Adds a Codex workflow for collecting a human-verified person, creator, brand, or organization's self-authored public Xiaohongshu, Douyin, and Weibo posts through OpenCLI into a local Markdown dataset with stable source URLs, author checks, capture timestamps, and a provenance manifest.

## Problem it solves

Public posts are often scattered across platforms and hard to use safely for archives, knowledge bases, RAG, content audits, migration, research, or consented AI data preparation. This skill adds a repeatable setup, identity-verification, dry-run, collection, provenance, and review workflow while excluding private content, comments, guessed identities, and credential handling.

## Real tool backing

- Canonical upstream: https://github.com/yuwanpai2004-create/codex-skills
- Agent Reach: https://github.com/Panniantong/Agent-Reach
- OpenCLI: https://www.npmjs.com/package/@jackwener/opencli

## Included

- Agent Skill Exchange v1.2-compatible `SKILL.md`
- Direct and pinned third-party installation commands
- Prerequisites and user-local setup boundaries
- Account verification and dry-run workflow
- Rights, privacy, and authorship safeguards
- Failure-closed behavior and output review guidance

## Compatibility

- Primary framework: Codex
- Python 3.10+
- Chrome with the official OpenCLI extension
- User-controlled login for each selected platform

## Permissions and dependencies

- Reads only explicitly selected public profiles and posts
- Writes Markdown and JSON provenance files under the chosen local project
- Never requests passwords, cookies, session tokens, or CAPTCHA answers
- Installs pinned user-local dependencies only after user approval; no `sudo`

## Validation performed

- `python3 scripts/validate_skills.py --all`: 1/1 passed, 0 warnings
- Canonical upstream skill structure validation: passed
- Python syntax compilation: passed
- Portability scan: no machine-specific absolute paths or embedded credentials

## License

MIT
