### PR TITLE
Add BeachFinder Swim Spot Finder skill

### DIFF
--- a/skills/beachfinder-swim-spot-finder/SKILL.md
+++ b/skills/beachfinder-swim-spot-finder/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: "BeachFinder Swim Spot Finder"
+slug: "beachfinder-swim-spot-finder"
+description: "Finds and compares 184,900 swimming spots worldwide (beaches, lakes, bathing places) with live water temperature, wind, UV and wave signals, local guides and source-backed activity providers, via the public BeachFinder MCP server."
+category: "Integrations & Connectors"
+framework: "Multi-Framework"
+verification: listed
+source: "https://getbeachfinder.com"
+---
+
+# BeachFinder Swim Spot Finder
+
+Routes beach, swimming, surf, dive, snorkel, whitewater, vanlife and coastal-provider
+requests to the public [BeachFinder](https://getbeachfinder.com) MCP server: search
+and compare 184,900 swimming spots worldwide, pull live weather, water temperature,
+wind, UV and wave planning signals for the top results, read localized guides, and
+find source-backed local activity providers.
+
+The skill picks the narrowest useful tool (nearby/family search, surf, dive/snorkel,
+river/whitewater, vanlife, providers, guides, live conditions, or a 2-5 spot
+comparison), passes the right language code out of 14 supported languages, respects
+BeachFinder's provider verification tiers (`owner_verified`, `source_backed`,
+`mapped`), and never declares a spot safe to swim — it defers to official closures,
+flags, lifeguards and local authorities. Every result links back to
+[getbeachfinder.com](https://getbeachfinder.com).
+
+## Installation
+
+### OpenClaw
+
+```bash
+clawhub install beachfinder-swim-spot-finder
+```
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill directory into the
+skill folder used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/beachfinder-swim-spot-finder ~/.agent-skills/beachfinder-swim-spot-finder
+```
+
+### Requirements
+
+Requires the public BeachFinder MCP server (no API key, no account):
+
+```json
+{
+  "mcpServers": {
+    "beachfinder": { "type": "http", "url": "https://getbeachfinder.com/mcp" }
+  }
+}
+```
+
+Full skill source, references and the OpenAI-runtime manifest:
+https://github.com/troulin-a11y/beachfinder-skills


### PR DESCRIPTION
Adds a skill wrapping the public BeachFinder MCP server.

- Canonical source / homepage: https://getbeachfinder.com
- MCP endpoint (public, no auth): https://getbeachfinder.com/mcp
- Listed on the official MCP Registry as `com.getbeachfinder/beachfinder`
- Full skill source + Claude/OpenAI packaging: https://github.com/troulin-a11y/beachfinder-skills

Finds and compares 184,900 swimming spots worldwide with live conditions, guides and source-backed providers. Category `Integrations & Connectors`, framework `Multi-Framework` (works with Claude Code, ChatGPT Agents, OpenClaw and any MCP-capable runtime). Follows template/SKILL.md and spec/SKILL_SPEC.md v1.2.