### PR TITLE
Add Honey skill

### DIFF
--- a/skills/honey/SKILL.md
+++ b/skills/honey/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: "Honey"
+slug: "honey"
+description: "Use Honey to reduce unnecessary code and prose from AI coding agents while preserving correctness, safety, accessibility, and lossless agent handoffs."
+category: "Developer Tools"
+framework: "Codex"
+verification: listed
+source: "https://github.com/Green-PT/honey-for-devs"
+---
+
+# Honey
+
+Honey is an open-source GreenPT skill for Claude Code, Codex, Cursor, GitHub Copilot, Gemini CLI, Windsurf, Cline, OpenClaw, Kiro, and other coding agents. Use it when an agent writes speculative helpers, unnecessary abstractions, repeated explanations, or oversized handoffs. Honey separates three problems that require different treatment: unnecessary code, filler around code, and repeated structure in agent-to-agent messages.
+
+For code, Honey checks whether a change needs to exist, whether the repository already has a solution, and whether the standard library, language, or installed dependencies cover the requirement. It stops at the first complete solution. It never removes validation, error handling, authentication, accessibility, irreversible-work safeguards, or explicit requirements to make output shorter.
+
+For human responses, Honey removes wind-up, hedging, and narration when implementation is the deliverable. It retains explanations for design decisions, tradeoffs, correctness arguments, and learning tasks. For agent handoffs, it prefers compact lossless JSON and uses ESON only when repeated record arrays are large enough to justify the format primer.
+
+GreenPT publishes the benchmark method, raw results, corrections, and limitations in the source repository. Current public results report 29% lower median output across a 23-task mixed suite and up to 70% lower output in focused review workflows, with every objective test passing and no measurable overall quality loss.
+
+## Installation
+
+Install the maintained upstream skill:
+
+```bash
+npx skills add https://github.com/Green-PT/honey-for-devs --skill honey
+```
+
+Review the source and benchmark before use:
+
+```text
+https://github.com/Green-PT/honey-for-devs
+```


### PR DESCRIPTION
## What changed

Adds Honey as a Developer Tools skill with the required Agent Skill Exchange metadata, a source link to the maintained GreenPT repository, technical usage guidance, and an install command.

## Why

Honey is an open-source GreenPT skill for reducing unnecessary code and prose while preserving correctness, safety, accessibility, and lossless agent handoffs. Its benchmark method, raw results, corrections, and limitations are public.

## Validation

```text
bash scripts/validate-skill.sh skills/honey/SKILL.md
PASS  skills/honey/SKILL.md
Validation: 1/1 passed, 0 failed, 0 warnings.
```
