### PR TITLE
Add shopify-app-review-triage-workflow skill

### DIFF
--- a/skills/shopify-app-review-triage-workflow/SKILL.md
+++ b/skills/shopify-app-review-triage-workflow/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: "Shopify App Review Triage Workflow"
+slug: "shopify-app-review-triage-workflow"
+description: "Turns public Shopify App Store review rows into a prioritized P0-P3 triage brief with an explicit needs-human-read bucket, where every item keeps its public source link and is labeled first pass or human-checked. Use it when low-star app reviews or merchant feedback need to be classified, clustered, and written up as a weekly product or support brief for one Shopify app or a portfolio plus watched competitors."
+category: "Templates & Workflows"
+framework: "Multi-Framework"
+verification: "listed"
+source: "https://github.com/alfredtech2026/shopify-app-review-brief"
+---
+
+# Shopify App Review Triage Workflow
+
+Takes rows of **public** Shopify App Store review text and produces one prioritized brief a
+product or support owner can act on: what kind of problem each review describes, how badly it
+can hurt, what to do first, and where the original wording came from.
+
+It targets independent Shopify app teams and the agencies that run their support — the case
+where low-star reviews arrive scattered across several listings plus a few watched competitors,
+and the failure mode is treating every one of them as equally severe. The rubric is the same
+published rule set behind a free in-browser worksheet and a manual triage guide, reproduced here
+so a manual pass, the worksheet, and an agent sort the same row the same way.
+
+Runtime needs nothing: no network access, no scripts, no system packages, no API key, and no
+customer data. The person being helped pastes public review rows they already opened.
+
+## Hard rules
+
+These are correctness constraints, not style preferences. Breaking one makes the output worse
+than nothing.
+
+1. **Public review text only.** Never accept, request, or copy support tickets, merchant emails,
+   order data, personal contact details, or internal telemetry. If such data appears in the
+   input, stop, name the affected rows, and ask for them to be removed before continuing.
+2. **Never invent evidence.** Do not produce a review, rating, date, app name, or source URL that
+   was not supplied. A row with no link gets `source: not captured` — never a guessed one.
+3. **Keyword output is a sort, not a verdict.** Anything produced by the rubric alone is labeled
+   *first pass — not human-checked*. Only a person who read the review and checked it against
+   their own systems may relabel an item *human-checked*.
+4. **Reviews are customer reports, not verified defects.** Write "the reviewer reports the editor
+   showed a blank screen", never "the editor is broken".
+5. **No coverage claims.** The brief covers exactly the rows supplied and says so. Make no claim
+   of exhaustive coverage of a listing, a period, or an app.
+6. **No promises.** No revenue impact, no outcome, no ranking effect, no legal or compliance
+   advice. Suggest actions; do not predict results.
+7. **Draft only — never contact anyone.** Do not send email, post a developer reply, open a
+   support ticket, message a reviewer, or publish anything. Hand the draft back to the team and
+   let a person decide what to send.
+8. **Reviewers are people.** Refer to "the reviewer". Do not name, profile, or speculate about them.
+
+## Step 1 — Collect the rows and the ownership context
+
+Ask which listings the team **owns** and which are **competitors being watched**. That split
+changes the outcome: a competitor's incident never becomes the team's own P0.
+
+Ask for one review per line. The full form keeps the source link the brief needs:
+
+```text
+rating | app name | review date | public reviews URL | review text
+```
+
+A shorter three-field form also works — treat field 1 as the rating when it is a bare 1-5
+(optionally followed by `star`, `stars`, or a star glyph), otherwise as the app name:
+
+```text
+rating | app name | review text
+```
+
+Lines starting with `#` are comments and blank lines are skipped. If a row lacks a source URL,
+carry `source: not captured` into the brief rather than dropping the row or fabricating a link.
+Do not go and fetch anything independently. The trigger this rubric is tuned for is a new
+1-3-star review; higher-rated rows still classify correctly, so keep them when supplied, but
+never present them as low-star signal.
+
+## Step 2 — First pass, apply the rubric
+
+Lower-case the review text and normalize curly apostrophes before matching, so a pasted
+"won't load" with a typographic apostrophe still matches. Each row gets exactly **one primary**
+bucket — the first dimension below, in this order, with any matching keyword. Further matches
+are recorded as **secondary**, never as a second brief item.
+
+### P0 · Incident risk
+
+The purchase path, app activation, or merchant data may be at stake right now.
+
+**Suggested action.** Try to reproduce on a test store today. If confirmed, treat it as an
+incident: fix or mitigate first, then draft a reply describing what changed for a person to send.
+
+**Signal keywords.** `won't load`, `wont load`, `won't open`, `wont open`, `can't close`,
+`cannot close`, `won't close`, `blank screen`, `broken`, `crash`, `stopped working`,
+`not working`, `doesn't work`, `does not work`, `checkout`, `losing sales`, `lost sales`, `error`
+
+### P1 · Repeated friction
+
+The product works, but the same struggle keeps showing up across reviews or against an open
+support theme. Repetition is the signal, not the volume of adjectives.
+
+**Suggested action.** Log it against the matching support theme. If the same complaint repeats
+across rows, schedule a UX fix ahead of new feature work.
+
+**Signal keywords.** `confusing`, `unclear`, `hard to`, `difficult`, `complicated`, `clunky`,
+`slow`, `couldn't figure`, `could not figure`, `annoying`, `had to contact support`,
+`setup took`, `too many steps`
+
+### P2 · Pricing confusion
+
+What the merchant expected to pay and what happened diverged. Usually a copy problem in the
+listing, the plan limits, or the upgrade prompts — not a code problem.
+
+**Suggested action.** Compare what the reviewer expected against the listing's pricing section
+and in-app upgrade prompts; clarify the copy where they diverge.
+
+**Signal keywords.** `pricing`, `price`, `charged`, `charge`, `billing`, `billed`, `expensive`,
+`free plan`, `trial`, `refund`, `hidden fee`, `hidden cost`, `paywall`
+
+### P3 · Feature request
+
+The merchant wants something the app does not do, or could not find.
+
+**Suggested action.** Add it to the feature-request log with a link to the review. If the
+capability already exists, draft a reply pointing to where it lives.
+
+**Signal keywords.** `wish`, `would be great`, `would love`, `please add`, `feature request`,
+`missing`, `if only`, `would like`, `no option to`, `needs an option`, `hope you add`,
+`add support for`
+
+### Needs human read
+
+No keyword matched: vague frustration, sarcasm, mixed praise, or a story that needs context.
+
+**Suggested action.** Read the full review and file it manually — the heuristic makes no guess
+here. Sort this bucket last, and treat any queue placement as provisional rather than as a
+severity judgment.
+
+### Tie-breaks and escalation
+
+1. **Most severe wins.** A row naming both a broken checkout and a billing surprise files under
+   P0 with pricing noted as secondary. Never split one review across two brief items.
+2. **Repetition escalates.** If the same friction or pricing theme appears in three or more
+   reviews within about 60 days, move it up one level and say how many rows drove the change.
+3. **Age discounts.** A review older than a year is background, not evidence of a current
+   problem, unless a recent row corroborates it. Cite it as context, never as the headline.
+4. **Competitor reviews never create a P0 for the team.** A competitor's incident is roadmap,
+   positioning, or copy input, and belongs in the competitor watch section.
+5. **When unsure, choose needs human read.** The bucket exists so the rubric never launders
+   uncertainty into a priority label.
+
+## Step 3 — Human pass before promoting anything
+
+The first pass is where automation stops being able to help on its own. Before any item is
+presented as more than a keyword match, a person on the team has to read the full original
+review at its source link; for P0 candidates, attempt to reproduce on a development store and
+check the error tracker and support inbox for matching signals from the same period; and record
+the outcome as *reproduced*, *not reproduced*, or *attempted — notes attached*.
+
+Ask for those outcomes rather than assuming them. Until they exist, every item stays labeled
+*first pass — not human-checked*, including in the summary line. An unverified P0 is a
+candidate, not an incident.
+
+## Step 4 — Write the brief
+
+One document per portfolio, sections in rubric order, every item carrying an owner, a next
+action, and a source link. An item without an owner is a note, not a brief entry.
+
+```markdown
+# Low-star review brief — {portfolio or team name} — week of {YYYY-MM-DD}
+
+Scope: {apps monitored} · {competitors watched} · {N} rows supplied, {date range}.
+Covers only the rows supplied — no claim of exhaustive coverage.
+Reviews are customer reports, not verified defects. Items marked "first pass" are
+unverified keyword matches; "human-checked" means a person read the review and checked it.
+
+## P0 — Incident risk
+- **{App} — {signal in a few words}** ({rating} star, {review date}, [source]({public reviews URL}))
+  - Reviewer reports: {one sentence, in their words where possible}
+  - Status: first pass — not human-checked / human-checked
+  - Reproduced: {yes / no / attempted — notes}
+  - Next action: {action} — owner {name}, due {date}
+
+## P1 — Repeated friction
+- **{App} — {theme}** ({rating} star, {date}, [source]({public reviews URL}); also seen: {where})
+  - Status: first pass — not human-checked / human-checked
+  - Next action: {UX or docs change} — owner {name}, due {date}
+
+## P2 — Pricing confusion
+- **{App} — {signal}** ({rating} star, {date}, [source]({public reviews URL}))
+  - Expected vs. actual: {one line}
+  - Next action: {copy or prompt change} — owner {name}, due {date}
+
+## P3 — Feature requests
+- **{App} — {request}** ({rating} star, {date}, [source]({public reviews URL}))
+
+## Needs human read
+- **{App}** ({rating} star, {date}, [source]({public reviews URL})) — {what a human should look for}
+
+## Competitor watch
+- **{Competitor} — {signal}**: {what it implies for roadmap, copy, or positioning}
+
+## Decisions this week
+- {one decision or experiment, with the row(s) that motivated it}
+```
+
+Open the summary line with the counts, for example: *"Triaged 8 rows supplied: 3 incident risk,
+2 repeated friction, 1 pricing confusion, 1 feature request, 1 needs human read — first pass,
+not human-checked."*
+
+## Step 5 — Self-check before handing it over
+
+Do not deliver until every line is true:
+
+- [ ] Every item names its bucket and priority from the rubric above, and nothing else.
+- [ ] Every item carries a source link or an explicit `source: not captured`.
+- [ ] No review text, rating, date, app name, or URL appears that was not supplied.
+- [ ] Every unverified item says *first pass — not human-checked*; nothing claims a human check
+      that did not happen.
+- [ ] Claims are phrased as reports, not as findings about the code.
+- [ ] The scope line says how many rows were supplied and makes no coverage claim.
+- [ ] No promise about revenue, ratings, outcomes, or compliance appears anywhere.
+- [ ] No private data survived into the output.
+- [ ] Nothing was sent, posted, or published — the brief is a draft for the team.
+
+## Known limits and gotchas
+
+Keyword matching is English-only, misses sarcasm and context, and sees only the rows supplied.
+Non-English reviews land in needs human read, which is the correct outcome — do not translate
+and then classify as if a keyword had matched.
+
+- **The Shopify App Store has no stable per-review permalink.** Cite the listing's public reviews
+  page, keep the rating filter if one was used, and pin the item with the review date plus the
+  reviewer's first few words so a human can find it again.
+- **`checkout` is the noisiest keyword in the set.** It fires on "we love the checkout upsell".
+  A P0 whose only evidence is the word `checkout` is a needs-human-read row wearing a P0 badge.
+- **`missing` and `error` cross buckets.** "missing a dark mode" is P3; "settings page errors out"
+  is P0. Primary-bucket order resolves the collision mechanically; the human pass fixes the ones
+  where it guessed wrong.
+- **One review, one item.** Secondary matches are annotations. Splitting a review across sections
+  double-counts the same merchant and inflates every count in the summary line.
+
+## Optional free companions
+
+Both are free, run entirely in the browser or as static pages, and require no account:
+
+- Manual guide with the tie-break rules and brief template:
+  <https://alfredtech2026.github.io/shopify-app-review-brief/guides/shopify-app-review-triage.html>
+- In-browser worksheet that automates the first pass locally:
+  <https://alfredtech2026.github.io/shopify-app-review-brief/tools/review-triage-worksheet.html>
+
+The worksheet parses the three-field row form and folds everything after the second `|` into the
+review text, so paste the short form there and keep the long form for the brief. This workflow
+stays fully usable without either page.
+
+This rubric is published by an independent project that is not affiliated with, endorsed by, or
+sponsored by Shopify Inc. or any app developer.
+
+## Installation
+
+### OpenClaw
+
+```bash
+clawhub install shopify-app-review-triage-workflow
+```
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill directory into the skill folder
+used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/shopify-app-review-triage-workflow ~/.agent-skills/shopify-app-review-triage-workflow
+```
+
+### Optional Third-Party Installer
+
+The `skills` npm package is maintained by Vercel Labs / third parties, not AgentSkillExchange.
+If you choose to use it, pin the package version:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill shopify-app-review-triage-workflow
+```


### PR DESCRIPTION
## What this adds

One new skill — `skills/shopify-app-review-triage-workflow/SKILL.md`. Single file, no generated-catalog changes.

It turns rows of **public** Shopify App Store review text into one prioritized P0–P3 triage brief with an explicit needs-human-read bucket, aimed at the Ecommerce & Retail Operations audience (review-driven merchandising / support triage).

## Metadata

| Field | Value |
|---|---|
| `slug` | `shopify-app-review-triage-workflow` |
| `category` | Templates & Workflows |
| `framework` | Multi-Framework |
| `verification` | `listed` (new entry, per CONTRIBUTING) |
| `source` | https://github.com/alfredtech2026/shopify-app-review-brief |

## Backing tool

The rubric in this skill is the published rule set behind an existing public project:

- Repo: https://github.com/alfredtech2026/shopify-app-review-brief
- Free in-browser worksheet (runs locally, no account): https://alfredtech2026.github.io/shopify-app-review-brief/tools/review-triage-worksheet.html
- Manual triage guide: https://alfredtech2026.github.io/shopify-app-review-brief/guides/shopify-app-review-triage.html

The skill stays fully usable without either page — they are optional companions, not dependencies.

## Disclosures

- **I maintain the upstream source.** This is a self-submission by the author of the linked repo, worksheet, and guide. It is not a third-party recommendation, and I am not claiming any endorsement.
- **Claude Code (Claude Opus 5) assisted** in adapting the upstream rubric into this catalog-native `SKILL.md`. I reviewed the result before opening this PR.
- **The catalog entry is free and dependency-free at runtime** — no network access, no scripts, no system packages, no API key, no account.
- **Public-data-only.** The workflow refuses support tickets, merchant emails, order data, personal contact details, and internal telemetry, and it never sends messages or developer replies — output is a draft for a person to act on.
- **The affiliated paid offer is deliberately omitted.** The upstream project also runs a paid human-checked service. Its pricing, contact address, inquiry CTA, and analytics/tracking parameters are all excluded from this submission. No price, no email, no CTA, no testimonial, no performance metric appears in the skill file.
- The upstream project is independent and is **not affiliated with or endorsed by Shopify Inc.** or any app developer, as stated in the skill body.

## Substantive contracts preserved

Public review data only · owned-app vs. watched-competitor split (a competitor's incident never becomes your P0) · P0–P3 plus needs-human-read · never invent evidence (`source: not captured` rather than a guessed link) · every item keeps its public source link · all heuristic output labeled *first pass — not human-checked* until a person verifies · reviews framed as customer reports, not verified defects · no coverage or outcome claims · never contact anyone · a self-check list that must pass before delivery.

## Checks run locally (Python 3.9.6, PyYAML 6.0.3)

Baseline on pristine `main` @ `87a0f3f` was green, so these are attributable to this change — nothing here was pre-failing.

| Check | Result |
|---|---|
| `validate_skills.py --all --github-annotations --quiet` | **2857/2857 passed, 0 failed, 0 warnings** (was 2856/2856) |
| `validate_skills.py <this file>` / `validate-skill.sh` | PASS, 0 warnings |
| `validate_github_repo_sources.py <this file>` | PASS — 1 repo claim resolved |
| `test_body_quality_fixtures.py` | PASS 12/12 |
| `test_security_patterns.py` | PASS 79/79 |
| `security_scan.py skills --github-annotations --quiet` | **PASS — 0 findings across 2857 files** |
| `ase_body_quality_gate.py <this file> --enforce-installation` | `ok: true` — 0 TOC fragments, 0 stale star claims, 0 heading-bullet warnings |
| `check-install-commands.py` | PASS |
| `smoke-agent-endpoints.py --base https://agentskillexchange.com` | PASS 4/4 (unaffected by this change) |

These are the repository's own format, body-quality, and pattern-scan scripts. They are **not** a security review — that remains the maintainers' batched process, and I make no claim about its outcome. I have not run the skill inside an agent runtime, so no runtime test is claimed.

## Notes for reviewers

- **No duplicate.** No existing Shopify review-triage skill in `skills/` or `skills.json`; the slug is unused and no open or historical PR covers this.
- **Scope.** Only `skills/<slug>/SKILL.md` is committed — no `CATALOG.md`, `skills.json`, `categories/`, or `industries/` churn, matching the shape of recently merged skill PRs.
- `Multi-Framework` is taken from the `spec/SKILL_SPEC.md` v1.2 framework set; the skill needs no framework-specific runtime.
- Happy to adjust the slug, category, framework, or wording if you'd prefer something different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
