### PR TITLE
Fix OutageDeck skill security scan wording

### DIFF
--- a/skills/outagedeck-dependency-outage-triage/SKILL.md
+++ b/skills/outagedeck-dependency-outage-triage/SKILL.md
@@ -80,7 +80,7 @@ Report a compact table with provider, current status, affected services, active 
 
 - Prefer public read-only MCP or REST interfaces.
 - Never invent a provider status, incident, service, source URL, or update time.
-- Do not roll back a deployment, change code, or disable security controls solely because a provider is degraded.
+- Do not roll back a deployment, change code, or weaken security controls solely because a provider is degraded.
 - Never request or paste an OutageDeck API key in chat.
 - Account mutation tools require the user's explicit request and the host's confirmation rules. Treat `remove_custom_provider` as destructive and require confirmation of the exact provider immediately before use.
 


### PR DESCRIPTION
## Summary

- replace the safety phrase `disable security controls` with `weaken security controls`
- preserve the original safety requirement while avoiding the catalog scanner's `social.disable_security` false positive

This fixes both post-merge checks on `main` after #30.

## Validation

- `python3 scripts/validate_skills.py --all --github-annotations --quiet` — 2862/2862 passed
- `python3 scripts/validate_github_repo_sources.py skills/outagedeck-dependency-outage-triage/SKILL.md` — passed
- `python3 scripts/test_body_quality_fixtures.py` — 12/12 matched
- `python3 scripts/test_security_patterns.py` — 79 patterns passed
- `python3 scripts/security_scan.py skills --github-annotations --quiet` — 0 findings
- `python3 scripts/smoke-agent-endpoints.py --base https://agentskillexchange.com` — 4/4 passed

Disclosure: I am affiliated with OutageDeck.