### PR TITLE
feat: add ImagineVid AI Generation skill

### DIFF
--- a/skills/imaginevid-ai-generation/SKILL.md
+++ b/skills/imaginevid-ai-generation/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: "ImagineVid AI Generation"
+slug: "imaginevid-ai-generation"
+description: "Use ImagineVid's OAuth-protected MCP and CLI tools to discover and safely run current image, video, and music generation capabilities."
+category: "Image & Creative Automation"
+framework: "MCP"
+verification: listed
+source: "https://github.com/imagineVid/agent-skills"
+---
+
+# ImagineVid AI Generation
+
+Use this Skill when a user wants to create an AI image, video, or music track
+through the [ImagineVid AI generation platform](https://imaginevid.io/). It
+connects an agent to ImagineVid's OAuth-protected, provider-neutral capability
+catalog instead of hard-coding individual model providers. The public source
+and complete workflow are available at
+https://github.com/imagineVid/agent-skills/tree/main/skills/imaginevid-ai-generation.
+
+## Installation
+
+Install the public Skill package for a compatible agent:
+
+```bash
+npx skills add https://github.com/imagineVid/agent-skills --skill imaginevid-ai-generation
+```
+
+Then connect the host to the ImagineVid remote MCP endpoint through its OAuth
+flow:
+
+```text
+https://imaginevid.io/api/mcp
+```
+
+Do not ask users to paste access tokens, cookies, or provider credentials.
+
+## Workflow
+
+1. Call `models_list` and select a capability ID returned by the live catalog.
+2. Upload local media through a trusted host surface and pass only the owned
+   `assetId` values returned by that surface.
+3. Call `generation_quote` with the selected capability, prompt, values, and
+   assets. Treat the server quote and normalized request as authoritative.
+4. Show the capability, important inputs, and exact credit quote. Ask the
+   human for explicit approval before any credit-consuming operation.
+5. Call `generation_create` once with the approved quote and a stable,
+   idempotent request ID. Never retry an ambiguous submission automatically.
+6. Poll the owned result with `generation_get` and report only safe status,
+   errors, and result metadata returned by the server.
+
+## Safety
+
+Generation can consume user credits. A vague request to generate is not enough
+to authorize spending. Stop on `insufficient_credits`, `forbidden_scope`, or
+invalid input. Treat `submission_unknown` as non-retryable and continue polling
+the durable generation when one is available. Never expose provider endpoints,
+callback URLs, local filesystem paths, raw tokens, or private account data.

--- a/skills/imaginevid-ai-generation/SKILL.md
+++ b/skills/imaginevid-ai-generation/SKILL.md
@@ -5,7 +5,7 @@ description: "Use ImagineVid's OAuth-protected MCP and CLI tools to discover and
 category: "Image & Creative Automation"
 framework: "MCP"
 verification: listed
-source: "https://github.com/imagineVid/agent-skills"
+source: "https://github.com/imagineVid/agent-skills/tree/main/skills/imaginevid-ai-generation"
 ---
 
 # ImagineVid AI Generation
@@ -19,10 +19,12 @@ https://github.com/imagineVid/agent-skills/tree/main/skills/imaginevid-ai-genera
 
 ## Installation
 
-Install the public Skill package for a compatible agent:
+Clone the public Skill package and copy the skill folder into the host's local
+skills directory:
 
 ```bash
-npx skills add https://github.com/imagineVid/agent-skills --skill imaginevid-ai-generation
+git clone https://github.com/imagineVid/agent-skills.git
+cp -R agent-skills/skills/imaginevid-ai-generation ~/.agent-skills/imaginevid-ai-generation
 ```
 
 Then connect the host to the ImagineVid remote MCP endpoint through its OAuth


### PR DESCRIPTION
## Summary
- Add the public ImagineVid AI Generation Skill for OAuth-protected image, video, and music workflows.
- Document live capability discovery, authoritative credit quotes, explicit approval, idempotent creation, and owned-result polling.
- Include public source and website links without secrets or provider-specific credentials.

## Verification
- `python3 scripts/validate_skills.py skills/imaginevid-ai-generation/SKILL.md`
- `python3 scripts/security_scan.py skills/imaginevid-ai-generation/SKILL.md`

## Public links
- Website: https://imaginevid.io/
- Skill source: https://github.com/imagineVid/agent-skills/tree/main/skills/imaginevid-ai-generation
- MCP/CLI adapters: https://github.com/imagineVid/imaginevid-agent-tools-ai