### PR TITLE
Add Unified AI System gateway skill

### DIFF
--- a/skills/unified-ai-gateway
+++ b/skills/unified-ai-gateway
@@ -1,0 +1,44 @@
+---
+name: "Unified AI System Gateway"
+slug: "unified-ai-gateway"
+description: "Turn plain-language requests into structured, reviewable prompts and inspect a self-hosted MCP gateway with provider-free defaults."
+category: "Developer Tools"
+framework: "Codex"
+verification: listed
+source: "https://github.com/happy520ai/unified-ai-system"
+---
+
+# Unified AI System Gateway
+
+Use this skill when a Codex workflow needs a self-hosted MCP gateway that makes
+ordinary language more precise before an agent acts. Unified AI System keeps
+the original request visible, compiles execution requirements, output
+constraints, clarification questions, and completion criteria, then exposes
+the result through a provider-free local path.
+
+## What it provides
+
+- A published MCP stdio server with nine bounded tools.
+- Deterministic prompt enhancement through `gateway_prompt_enhance`.
+- Health and readiness checks before chat or workflow operations.
+- A local fake-provider default that requires no provider key or account.
+- Explicit evidence fields such as `providerCalled`, `deterministic`, detected
+  signals, and compiled sections.
+
+## Safe first run
+
+Install the published MCP server only after reviewing the command and asking
+for approval to change the local Codex configuration:
+
+```bash
+codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.7
+```
+
+Restart Codex, inspect the server with `/mcp verbose`, and call
+`gateway_health` followed by `gateway_readiness` before using chat. Keep the
+fake-provider mode for the first run. Never add provider keys to a public
+configuration, and do not infer production readiness, L5 autonomy, or AGI
+from a successful MCP handshake.
+
+Project documentation and the provider-free verification workflow are available
+at https://github.com/happy520ai/unified-ai-system.

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -31,7 +31,7 @@ Install the published MCP server only after reviewing the command and asking
 for approval to change the local Codex configuration:
 
 ```bash
-codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.7
+codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.8
 ```
 
 Restart Codex, inspect the server with `/mcp verbose`, and call

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -35,7 +35,7 @@ required review and approval sequence:
 - Official skill and guarded setup procedure:
   https://github.com/happy520ai/unified-ai-system/tree/master/skills/unified-ai-gateway
 - Reviewed immutable image identity and residual risks:
-  https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.0.md
+  https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.9.md
 - MCP behavior and provider-free verification guide:
   https://github.com/happy520ai/unified-ai-system/blob/master/packages/mcp-server/README.md
 

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -5,7 +5,7 @@ description: "Turn plain-language requests into structured, reviewable prompts a
 category: "Developer Tools"
 framework: "Codex"
 verification: listed
-source: "https://github.com/happy520ai/unified-ai-system"
+source: "https://github.com/happy520ai/unified-ai-system/tree/master/skills/unified-ai-gateway"
 ---
 
 # Unified AI System Gateway
@@ -27,18 +27,25 @@ the result through a provider-free local path.
 
 ## Safe first run
 
-Install the published MCP server only after reviewing the command and asking
-for approval to change the local Codex configuration:
+Treat this catalog entry as a discovery document, not as authorization to pull
+an image, create a container, or modify Codex configuration. The upstream
+official skill classifies the integration as `risk: critical` and defines the
+required review and approval sequence:
 
-```bash
-codex mcp add unified-ai-system -- docker run --rm -i ghcr.io/happy520ai/unified-ai-system/mcp-server:0.4.8
-```
+- Official skill and guarded setup procedure:
+  https://github.com/happy520ai/unified-ai-system/tree/master/skills/unified-ai-gateway
+- Reviewed immutable image identity and residual risks:
+  https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.0.md
+- MCP behavior and provider-free verification guide:
+  https://github.com/happy520ai/unified-ai-system/blob/master/packages/mcp-server/README.md
 
-Restart Codex, inspect the server with `/mcp verbose`, and call
-`gateway_health` followed by `gateway_readiness` before using chat. Keep the
-fake-provider mode for the first run. Never add provider keys to a public
-configuration, and do not infer production readiness, L5 autonomy, or AGI
-from a successful MCP handshake.
+Follow that procedure exactly. Keep image download and non-executing content
+inspection under one explicit approval, then obtain separate approval before
+MCP registration or activation. Do not replace the reviewed digest with a
+mutable tag, enable container networking, mount host paths, pass credentials,
+or activate an unreviewed platform.
 
-Project documentation and the provider-free verification workflow are available
-at https://github.com/happy520ai/unified-ai-system.
+After an approved installation, restart Codex, inspect the server with
+`/mcp verbose`, and call `gateway_health` followed by `gateway_readiness`
+before using chat. Keep the fake-provider mode for the first run, and do not
+infer production readiness, L5 autonomy, or AGI from a successful handshake.


### PR DESCRIPTION
## Summary

Add Unified AI System to the Agent Skill Exchange catalog as a Codex-oriented skill backed by its public Apache-2.0 repository.

## Why it fits

- Wraps a real, maintained upstream project: https://github.com/happy520ai/unified-ai-system
- Provides a published MCP stdio server with nine bounded tools.
- Turns plain-language requests into structured, reviewable prompts through a provider-free deterministic path.
- Documents health/readiness checks and keeps provider calls explicit.
- Preserves the upstream critical-risk setup and evidence boundaries without claiming production readiness, L5 autonomy, or AGI.

## Review changes

- The source field now points to the exact official upstream skill:
  https://github.com/happy520ai/unified-ai-system/tree/master/skills/unified-ai-gateway
- Removed the mutable-tag Codex MCP install command from the ASE entry.
- Reframed the entry as discovery documentation, not install authorization.
- Linked the official guarded setup, immutable image review, and MCP behavior guide.
- Made image download/content inspection and registration/activation separate approval stages.
- Explicitly prohibits mutable-tag substitution, unreviewed platforms, networking, host mounts, and credentials.

## Verification boundary

The skill uses verification: listed because this PR is a catalog submission, not a third-party security certification. The upstream official skill classifies the integration as risk: critical; users must follow its reviewed immutable-image procedure rather than infer safety from this listing.

## Current branch verification

- python scripts/validate_skills.py skills/unified-ai-gateway/SKILL.md: 1/1 passed, 0 warnings
- python scripts/security_scan.py skills/unified-ai-gateway/SKILL.md --github-annotations --quiet: 0 findings
- python scripts/ase_body_quality_gate.py skills/unified-ai-gateway/SKILL.md: ok: true
- python scripts/validate_skills.py --all --quiet: 2875/2875 passed, 0 warnings
- python scripts/test_security_patterns.py: 79 fixtures passed
- python scripts/check-install-commands.py: passed
- git diff --check: passed

The external Actions runs still require maintainer approval; this is not being represented as a CI pass.