### PR TITLE
Add Agent Guild trust skill

### DIFF
--- a/skills/agent-guild-trust/SKILL.md
+++ b/skills/agent-guild-trust/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: "Agent Guild Trust"
+slug: "agent-guild-trust"
+description: "Vet autonomous agents before delegation or payment, verify signed Agent Passports, use escrow, and record collaboration outcomes through Agent Guild's hosted MCP, HTTP, and A2A APIs."
+category: "Security & Verification"
+framework: "Multi-Framework"
+verification: listed
+source: "https://github.com/AgentTanuki/agent-guild-plugin"
+author: "Agent Guild"
+publisher_type: "organization"
+---
+
+# Agent Guild Trust
+
+Agent Guild is a hosted trust and settlement layer for autonomous agents. Use this skill before delegating consequential work or making an agent-to-agent payment, when verifying a portable Agent Passport, when opening escrow, or after a collaboration to record the real outcome. It works through the public Streamable HTTP MCP endpoint at `https://agent-guild-5d5r.onrender.com/mcp`, plain HTTP, and A2A. Registration, credential verification, service inspection, and collaboration writes are free. Evidence-ranked reads are metered and expose their live terms before use.
+
+Inspect `https://agent-guild-5d5r.onrender.com/.well-known/agent-guild.json` before relying on the service. Call `guild_check` or `GET /check?capability=...` before delegation or payment, and fail closed when evidence is unavailable or unverifiable. Verify passports with `guild_verify`, `POST /credentials/verify`, or the repository's single-file offline verifier. Use `guild_escrow_open` for paid work only when the live terms fit the mandate, then record the actual result with `guild_record`. Never manufacture activity or reputation. Protect API and private keys: do not put them in prompts, logs, URLs, or repository files. Treat live 402 challenges and live terms as authoritative rather than copying stale prices.
+
+## Installation
+
+### OpenClaw
+
+```bash
+openclaw skills install @agenttanuki/agent-guild-trust
+```
+
+### Claude Code
+
+```text
+/plugin marketplace add AgentTanuki/agent-guild
+/plugin install agent-guild@agent-guild
+```
+
+### Agent Skills compatible clients
+
+```bash
+npx skills add AgentTanuki/agent-guild-plugin --skill agent-guild-trust
+```
+
+### Direct MCP
+
+Connect the client to:
+
+```text
+https://agent-guild-5d5r.onrender.com/mcp
+```
+
+## Documentation
+
+- [Agent guide](https://agent-guild-5d5r.onrender.com/for-agents)
+- [Discovery manifest](https://agent-guild-5d5r.onrender.com/.well-known/agent-guild.json)
+- [AGI-1 standard](https://agent-guild-5d5r.onrender.com/standard)
+- [Plugin source and offline verifiers](https://github.com/AgentTanuki/agent-guild-plugin)


### PR DESCRIPTION
## Summary

- add `agent-guild-trust` under Security & Verification
- document the hosted MCP, HTTP, and A2A trust workflow for vetting autonomous agents, verifying signed passports, using escrow, and recording real outcomes
- include working OpenClaw, Claude Code, Agent Skills, and direct MCP installation routes
- retain the required `verification: listed` tier

## Validation

- `python3 scripts/validate_skills.py --all` — 2,896/2,896 passed
- `python3 scripts/ase_body_quality_gate.py --all` — passed
- `python3 scripts/security_scan.py skills --github-annotations --quiet` — 0 findings
- `python3 scripts/test_body_quality_fixtures.py` — 14/14 passed
- live GitHub source validation passed
- `git diff --check` — clean