### PR TITLE
Add hypergrok-trading-desk

### DIFF
--- a/skills/hypergrok-trading-desk/SKILL.md
+++ b/skills/hypergrok-trading-desk/SKILL.md
@@ -6,10 +6,10 @@ category: "Integrations & Connectors"
 framework: "Multi-Framework"
 verification: listed
 source: "https://github.com/galleonlabs/hypergrok-trading-desk"
-github_stars: 2
+github_stars: 1
 tool_ecosystem:
   github_repo: "galleonlabs/hypergrok-trading-desk"
-  github_stars: 2
+  github_stars: 1
   license: "MIT"
   maintained: true
 ---
@@ -19,8 +19,6 @@ tool_ecosystem:
 HyperGrok is an open-source Agent Plugin that turns an agent workspace into a seven-role Hyperliquid trading desk. It ships sixteen portable `SKILL.md` skills and seven role prompts. The desk is documentation and instructions, not a hosted bot.
 
 Use this skill when you want research, risk, ticketed execution, and review as separate seats on Hyperliquid perpetual markets.
-
-## What it includes
 
 **Roles:** Desk Lead, Market Analyst, Research Analyst, Strategist, Risk Manager, Execution Trader, Trade Reviewer.
 
@@ -32,10 +30,39 @@ Every trade follows the same path: idea → evidence → risk sign-off → your 
 
 ## Installation
 
-### Direct repo
+### OpenClaw
 
 ```bash
-npx skills add galleonlabs/hypergrok-trading-desk
+clawhub install hypergrok-trading-desk
+```
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill directory into the skill folder used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/hypergrok-trading-desk ~/.agent-skills/hypergrok-trading-desk
+```
+
+The full sixteen-skill desk also lives upstream:
+
+```bash
+git clone https://github.com/galleonlabs/hypergrok-trading-desk.git
+```
+
+### Optional Third-Party Installer
+
+The `skills` npm package is maintained by Vercel Labs / third parties, not AgentSkillExchange. If you choose to use it, pin the package version:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill hypergrok-trading-desk
+```
+
+Upstream pack install:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add galleonlabs/hypergrok-trading-desk
 ```
 
 ### Claude Code marketplace
@@ -50,10 +77,6 @@ claude plugin install hypergrok@hypergrok
 ```bash
 hermes plugins install galleonlabs/hypergrok-trading-desk
 ```
-
-### OpenClaw / ClawHub
-
-Skills are published under the `galleonlabs` publisher as `hypergrok-*` slugs (for example `hypergrok-desk-operating-model`).
 
 ### Grok Bot
 

--- a/skills/hypergrok-trading-desk/SKILL.md
+++ b/skills/hypergrok-trading-desk/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: "HyperGrok Trading Desk"
+slug: "hypergrok-trading-desk"
+description: "Turn Claude Code, Cursor, or Grok Bot into a 7-role Hyperliquid trading desk. Sixteen SKILL.md skills plus seven agent prompts cover market data, risk limits, ticketed execution, and post-trade review. You approve every trade by ticket id. Trade-only API wallet; no withdraw."
+category: "Integrations & Connectors"
+framework: "Multi-Framework"
+verification: listed
+source: "https://github.com/galleonlabs/hypergrok-trading-desk"
+github_stars: 2
+tool_ecosystem:
+  github_repo: "galleonlabs/hypergrok-trading-desk"
+  github_stars: 2
+  license: "MIT"
+  maintained: true
+---
+
+# HyperGrok Trading Desk
+
+HyperGrok is an open-source Agent Plugin that turns an agent workspace into a seven-role Hyperliquid trading desk. It ships sixteen portable `SKILL.md` skills and seven role prompts. The desk is documentation and instructions, not a hosted bot.
+
+Use this skill when you want research, risk, ticketed execution, and review as separate seats on Hyperliquid perpetual markets.
+
+## What it includes
+
+**Roles:** Desk Lead, Market Analyst, Research Analyst, Strategist, Risk Manager, Execution Trader, Trade Reviewer.
+
+**Hyperliquid skills:** API wallet setup, market data, account state, orders (limit, IOC, take-profit, stop-loss, grouping, client order ids), positions and margin, WebSocket feeds, advanced actions (dead-man's switch, TWAP, spot), and a compact API reference.
+
+**Desk skills:** operating model, trade lifecycle and ticket, risk limits and sizing, execution protocol, monitoring, post-trade review, incident playbooks, and the strategy lab.
+
+Every trade follows the same path: idea → evidence → risk sign-off → your approval by ticket id → one send → reconciliation → review. A trade-only API wallet is the only key the desk holds. It can trade; it cannot withdraw. Testnet first.
+
+## Installation
+
+### Direct repo
+
+```bash
+npx skills add galleonlabs/hypergrok-trading-desk
+```
+
+### Claude Code marketplace
+
+```bash
+claude plugin marketplace add galleonlabs/hypergrok-trading-desk
+claude plugin install hypergrok@hypergrok
+```
+
+### Hermes
+
+```bash
+hermes plugins install galleonlabs/hypergrok-trading-desk
+```
+
+### OpenClaw / ClawHub
+
+Skills are published under the `galleonlabs` publisher as `hypergrok-*` slugs (for example `hypergrok-desk-operating-model`).
+
+### Grok Bot
+
+Paste the setup prompt from the upstream README: follow `SETUP.md` to create the seven Bots and the Trading Floor group chat.
+
+## Source
+
+- Upstream: https://github.com/galleonlabs/hypergrok-trading-desk
+- Homepage: https://galleonlabs.io
+- License: MIT
+- Agent Plugins 1.0.0 `plugin.json` at repo root

--- a/skills/hypergrok-trading-desk/SKILL.md
+++ b/skills/hypergrok-trading-desk/SKILL.md
@@ -6,10 +6,8 @@ category: "Integrations & Connectors"
 framework: "Multi-Framework"
 verification: listed
 source: "https://github.com/galleonlabs/hypergrok-trading-desk"
-github_stars: 1
 tool_ecosystem:
   github_repo: "galleonlabs/hypergrok-trading-desk"
-  github_stars: 1
   license: "MIT"
   maintained: true
 ---
@@ -27,6 +25,10 @@ Use this skill when you want research, risk, ticketed execution, and review as s
 **Desk skills:** operating model, trade lifecycle and ticket, risk limits and sizing, execution protocol, monitoring, post-trade review, incident playbooks, and the strategy lab.
 
 Every trade follows the same path: idea → evidence → risk sign-off → your approval by ticket id → one send → reconciliation → review. A trade-only API wallet is the only key the desk holds. It can trade; it cannot withdraw. Testnet first.
+
+## Financial risk boundary
+
+HyperGrok is documentation and instructions, not financial advice. Perpetual futures can liquidate an account. Use testnet first, keep explicit risk limits, and require human approval before any mainnet order.
 
 ## Installation
 
@@ -56,13 +58,13 @@ git clone https://github.com/galleonlabs/hypergrok-trading-desk.git
 The `skills` npm package is maintained by Vercel Labs / third parties, not AgentSkillExchange. If you choose to use it, pin the package version:
 
 ```bash
-npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill hypergrok-trading-desk
+npm exec --package=skills@1.5.23 -- skills add agentskillexchange/skills --skill hypergrok-trading-desk
 ```
 
 Upstream pack install:
 
 ```bash
-npm exec --package=skills@1.5.7 -- skills add galleonlabs/hypergrok-trading-desk
+npm exec --package=skills@1.5.23 -- skills add galleonlabs/hypergrok-trading-desk
 ```
 
 ### Claude Code marketplace


### PR DESCRIPTION
## Summary
Adds a catalog entry for [galleonlabs/hypergrok-trading-desk](https://github.com/galleonlabs/hypergrok-trading-desk), an MIT Agent Plugin that turns Claude Code, Cursor, Grok Bot, or Hermes into a 7-role Hyperliquid trading desk.

- Sixteen portable `SKILL.md` skills plus seven role prompts
- Ticketed execution: you approve every trade by ticket id
- Trade-only API wallet; no withdraw
- Installation section follows the catalog template (OpenClaw, direct repo, pinned `skills@1.5.7`)

## Checklist
- [x] Public upstream repo with real `SKILL.md` files
- [x] Frontmatter matches the catalog spec
- [x] 100+ words of technical detail
- [x] Category: Integrations & Connectors
- [x] Framework: Multi-Framework (valid in `spec/SKILL_SPEC.md`)
- [x] `python3 scripts/validate_skills.py` passes locally
- [x] GitHub source claims resolve