### PR TITLE
Add Agent QA regression testing skill

### DIFF
--- a/skills/author-and-run-regression-tests-with-agent-qa/SKILL.md
+++ b/skills/author-and-run-regression-tests-with-agent-qa/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: "Author and Run Regression Tests with Agent QA"
+slug: "author-and-run-regression-tests-with-agent-qa"
+description: "Use Agent QA's CLI and MCP server to author, validate, run, debug, and triage natural-language web and mobile regression tests with persistent test memory and reviewable run evidence."
+category: "Browser Automation"
+framework: "Codex"
+verification: listed
+source: "https://github.com/vostride/agent-qa"
+---
+
+# Author and Run Regression Tests with Agent QA
+
+Use Agent QA when a coding task needs an application flow verified in a real browser or mobile environment. Agent QA stores tests as reviewable project files, accepts natural-language actions and assertions, and can retain scoped observations from earlier runs. Prefer its MCP tools when available: discover the workspace, inspect configuration, generate canonical IDs, validate test or suite definitions, and enqueue the run. Use the CLI as a fallback. When execution fails, inspect the recorded steps and evidence before changing the test; distinguish an application regression from an outdated instruction or an infrastructure failure. Agent QA can re-observe the interface and try another path during a run, but successful self-healing should still be reviewed before the learned path is trusted for later runs.
+
+Agent QA is currently source-available under FSL-1.1-ALv2. Each release converts to Apache-2.0 after two years. Configured model, browser, or device providers may have separate costs.
+
+## Prerequisites
+
+Install Agent QA in the project and initialize its workspace:
+
+```bash
+npm install -D agent-qa
+npx agent-qa init
+npx agent-qa install-browsers --chromium
+```
+
+For Android or iOS projects, install the required mobile drivers:
+
+```bash
+npx agent-qa install-mobile-drivers --all
+```
+
+## Workflow
+
+1. Discover the Agent QA workspace and inspect its active targets, devices, and providers.
+2. Generate IDs with Agent QA tooling; never invent test, suite, hook, run, or observation IDs.
+3. Create or update the natural-language test, then validate its definition before saving or running it.
+4. Enqueue the test or suite through MCP. If MCP is unavailable, run a validated file with `npx agent-qa run <test-file>`.
+5. Review step evidence, healing attempts, and retained observations before deciding whether to fix the application, revise the test, or retry infrastructure.
+
+## Installation
+
+### Direct repo/manual install
+
+Clone the Agent Skill Exchange repository and copy this skill into the directory used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/author-and-run-regression-tests-with-agent-qa ~/.agent-skills/author-and-run-regression-tests-with-agent-qa
+```
+
+### Optional Third-Party Installer
+
+The `skills` npm package is maintained by Vercel Labs / third parties, not AgentSkillExchange. If you choose to use it, pin the package version:
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill author-and-run-regression-tests-with-agent-qa
+```
+
+## Documentation
+
+- [Agent QA quickstart](https://vostride.com/docs/agent-qa/quickstart)
+- [Agent QA CLI reference](https://vostride.com/docs/agent-qa/cli)
+- [Agent QA source and license](https://github.com/vostride/agent-qa)


### PR DESCRIPTION
## Summary

Add a Browser Automation skill for authoring and running web and mobile regression tests with Agent QA.

The skill is backed by the published `agent-qa` package and canonical repository. It covers the MCP-first authoring workflow, CLI fallback, canonical ID generation, validation before execution, and evidence-based failure triage. Installation commands follow this repository's current template and pin the optional third-party installer version.

## Validation

- The repository's parser-backed skill validator passes.
- The body-quality and security checks pass.
- Agent QA's current installation and run commands were checked against its canonical README.
- The source, documentation, and license links are direct.

## Disclosure and license

I am affiliated with Agent QA/Vostride. Agent QA is currently source-available under FSL-1.1-ALv2, with each release converting to Apache-2.0 after two years. The skill states this explicitly and does not describe the current release as OSI open source.
