### PR TITLE
Fix README contributor for Automation Integration Preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ See the full overlay index in [industries/README.md](industries/README.md).
 
 | Contributor | Skill | What it helps with | Category |
 |---|---|---|---|
-| [gagankcai-jpg](https://github.com/gagankcai-jpg) | [Automation Integration Preflight](skills/automation-integration-preflight/) | Assess a public HTTP(S) page before building browser automation, extraction, or an integration. Use this skill to collect... | Integrations & Connectors |
+| TinyOps Studio LLC | [Automation Integration Preflight](skills/automation-integration-preflight/) | Assess a public HTTP(S) page before building browser automation, extraction, or an integration. Use this skill to collect... | Integrations & Connectors |
 | [pranshuchittora](https://github.com/pranshuchittora) | [Author and Run Regression Tests with Agent QA](skills/author-and-run-regression-tests-with-agent-qa/) | Use Agent QA's CLI and MCP server to author, validate, run, debug, and triage natural-language web and mobile... | Browser Automation |
 | [kantorcodes](https://github.com/kantorcodes) | [HOL Guard](skills/hol-guard/) | Protect local AI coding-agent harnesses before tools run, review approvals and evidence, and scan agent plugins, skills, MCP... | Security & Verification |
 | [giltotherescue](https://github.com/giltotherescue) | [Slashbooks](skills/slashbooks/) | Replace QuickBooks with an AI agent you control: import bank and credit card activity, categorize and reconcile transactions... | Calendar, Email & Productivity |

--- a/scripts/generate-readme.sh
+++ b/scripts/generate-readme.sh
@@ -27,6 +27,9 @@ HOMEPAGE_PICKS_URL = f"{SITE_BASE}/wp-json/ase-marketplace/v1/homepage-picks"
 INDUSTRY_MANIFEST = REPO_DIR / "scripts" / "industry-collections.json"
 GITHUB_API_BASE = os.environ.get("ASE_GITHUB_API_BASE", "https://api.github.com").rstrip("/")
 GITHUB_REPO = os.environ.get("ASE_GITHUB_REPO", "agentskillexchange/skills")
+CONTRIBUTOR_OVERRIDES = {
+    "automation-integration-preflight": "TinyOps Studio LLC",
+}
 
 CAT_EMOJI = {
     "CI/CD Integrations": "🔧", "Runbooks & Diagnostics": "📋",
@@ -325,12 +328,13 @@ def community_contribution_rows_from_prs(source_items, limit=10):
                 continue
             item = lookup.get(slug, {})
             frontmatter = repo_skill_frontmatter(slug)
+            contributor_name = CONTRIBUTOR_OVERRIDES.get(slug) or contributor
             title = display_name(item) or clean_text(frontmatter.get("name")) or slug.replace("-", " ").title()
             if not title:
                 continue
             seen.add(slug)
             rows.append({
-                "contributor": contributor,
+                "contributor": contributor_name,
                 "title": title,
                 "slug": slug,
                 "help": short_help(item or frontmatter),


### PR DESCRIPTION
## Summary

- Adds a scoped README contributor override for `automation-integration-preflight`
- Updates the README community contribution row from `gagankcai-jpg` to `TinyOps Studio LLC`
- Keeps the change limited to this one skill attribution case

## Validation

- `bash -n scripts/generate-readme.sh`
- Regenerated README in the review checkout and confirmed the row renders as `TinyOps Studio LLC`
