### PR TITLE
Link TinyOps contributor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See the full overlay index in [industries/README.md](industries/README.md).
 | Contributor | Skill | What it helps with | Category |
 |---|---|---|---|
 | [haoranyu](https://github.com/haoranyu) | [Clean Closed Issue Worktrees](skills/clean-closed-issue-worktrees/) | Safely audits and removes Git worktrees linked to closed GitHub or GitLab issues with a mandatory scan-confirm-execute protocol... | Developer Tools |
-| TinyOps Studio LLC | [Automation Integration Preflight](skills/automation-integration-preflight/) | Assess a public HTTP(S) page before building browser automation, extraction, or an integration. Use this skill to collect... | Integrations & Connectors |
+| [TinyOps Studio LLC](https://github.com/tinyopsstudio) | [Automation Integration Preflight](skills/automation-integration-preflight/) | Assess a public HTTP(S) page before building browser automation, extraction, or an integration. Use this skill to collect... | Integrations & Connectors |
 | [pranshuchittora](https://github.com/pranshuchittora) | [Author and Run Regression Tests with Agent QA](skills/author-and-run-regression-tests-with-agent-qa/) | Use Agent QA's CLI and MCP server to author, validate, run, debug, and triage natural-language web and mobile... | Browser Automation |
 | [kantorcodes](https://github.com/kantorcodes) | [HOL Guard](skills/hol-guard/) | Protect local AI coding-agent harnesses before tools run, review approvals and evidence, and scan agent plugins, skills, MCP... | Security & Verification |
 | [giltotherescue](https://github.com/giltotherescue) | [Slashbooks](skills/slashbooks/) | Replace QuickBooks with an AI agent you control: import bank and credit card activity, categorize and reconcile transactions... | Calendar, Email & Productivity |

--- a/scripts/generate-readme.sh
+++ b/scripts/generate-readme.sh
@@ -28,7 +28,7 @@ INDUSTRY_MANIFEST = REPO_DIR / "scripts" / "industry-collections.json"
 GITHUB_API_BASE = os.environ.get("ASE_GITHUB_API_BASE", "https://api.github.com").rstrip("/")
 GITHUB_REPO = os.environ.get("ASE_GITHUB_REPO", "agentskillexchange/skills")
 CONTRIBUTOR_OVERRIDES = {
-    "automation-integration-preflight": "TinyOps Studio LLC",
+    "automation-integration-preflight": "[TinyOps Studio LLC](https://github.com/tinyopsstudio)",
 }
 
 CAT_EMOJI = {


### PR DESCRIPTION
## Summary

- Updates the scoped Automation Integration Preflight contributor override to render as a GitHub profile link
- Regenerates README so the Recent Community Contributions row links TinyOps Studio LLC to https://github.com/tinyopsstudio

## Validation

- `bash -n scripts/generate-readme.sh`
- `bash scripts/generate-readme.sh`
- Confirmed README row renders as `[TinyOps Studio LLC](https://github.com/tinyopsstudio)`
