### PR TITLE
Add BulkPublish social publishing skill

### DIFF
--- a/skills/bulkpublish-social-publishing/SKILL.md
+++ b/skills/bulkpublish-social-publishing/SKILL.md
@@ -31,7 +31,7 @@ Clone this catalog and copy the skill directory into the skill location used by 
 
 ```bash
 git clone https://github.com/agentskillexchange/skills.git
-cp -R skills/skills/bulkpublish-social-publishing ~/.agent-skills/bulkpublish-social-publishing
+cp -R skills/bulkpublish-social-publishing ~/.agent-skills/bulkpublish-social-publishing
 ```
 
 ### Agent Skill Exchange installer

--- a/skills/bulkpublish-social-publishing/SKILL.md
+++ b/skills/bulkpublish-social-publishing/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: "BulkPublish Social Publishing"
+slug: "bulkpublish-social-publishing"
+description: "Adapt, review, schedule, and publish approved social content across multiple platforms through the BulkPublish API and hosted MCP."
+category: "Integrations & Connectors"
+framework: "MCP"
+verification: listed
+source: "https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills"
+---
+
+# BulkPublish Social Publishing
+
+Use this skill when an agent needs to move social content from a reviewed draft into an approved, scheduled, or published multi-platform campaign. BulkPublish supplies the API and hosted MCP layer for the operational handoff. The skill is useful for content teams, growth operators, and agent builders who need a repeatable approval boundary instead of ad hoc platform calls. It covers preparation, platform adaptation, scheduling, execution, and verification while keeping credentials and account details outside the skill.
+
+## References
+
+- BulkPublish API repository: https://github.com/azeemkafridi/bulkpublish-api
+- BulkPublish MCP documentation: https://app.bulkpublish.com/docs
+- Hosted MCP endpoint: https://mcp.bulkpublish.com/mcp
+- Source social-media content skills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills
+
+## Installation
+
+### MCP-compatible agents
+
+Configure the hosted endpoint from the BulkPublish documentation, or run the package described in the API repository. Keep tokens in the agent runtime's secret store or environment variables; never place them in prompts, skill files, or commits.
+
+### Direct repo/manual install
+
+Clone this catalog and copy the skill directory into the skill location used by your agent runtime:
+
+```bash
+git clone https://github.com/agentskillexchange/skills.git
+cp -R skills/skills/bulkpublish-social-publishing ~/.agent-skills/bulkpublish-social-publishing
+```
+
+### Agent Skill Exchange installer
+
+```bash
+npm exec --package=skills@1.5.7 -- skills add agentskillexchange/skills --skill bulkpublish-social-publishing
+```
+
+## Workflow
+
+1. Collect the approved source copy, media, links, target platforms and accounts, timezone, and requested schedule.
+2. Adapt content per platform while preserving approved claims, disclosures, consent, links, and brand constraints.
+3. Show the exact per-platform payload, media, account targets, and schedule to the user.
+4. Wait for explicit approval of that exact payload and target set before using a create, schedule, or publish tool.
+5. Use BulkPublish's API or hosted MCP to execute the approved operation.
+6. Retrieve each resulting status and report platform, account, scheduled time, identifier, URL, and errors.
+
+## Safety and failure handling
+
+- Publishing and scheduling are external side effects; never infer approval from an earlier draft or a different target set.
+- Never invent account IDs, media URLs, permissions, delivery results, or analytics.
+- If an external call times out, retrieve its status before retrying so the operation is not duplicated.
+- Report partial success per platform and leave failed targets unsent unless the user explicitly approves a retry.
+- Preserve platform disclosures, opt-outs, copyright notes, and human review requirements.
+
+## Output
+
+Return a compact status table with platform, account, operation, status, schedule, identifier, public URL when available, and unresolved follow-up actions.


### PR DESCRIPTION
Adds a complete BulkPublish social publishing skill under Integrations & Connectors.

The skill covers platform adaptation, exact-payload approval, scheduling/publishing through the BulkPublish API or hosted MCP, status verification, timeout deduplication, partial-success reporting, and secret handling.

- Source skills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills
- API: https://github.com/azeemkafridi/bulkpublish-api
- MCP docs: https://app.bulkpublish.com/docs

Disclosure: I maintain BulkPublish.